### PR TITLE
Don't register EntityRenderHandler twice + two performance improvements

### DIFF
--- a/src/main/java/net/gobbob/mobends/animation/keyframe/KeyframeAnimation.java
+++ b/src/main/java/net/gobbob/mobends/animation/keyframe/KeyframeAnimation.java
@@ -1,7 +1,6 @@
 package net.gobbob.mobends.animation.keyframe;
 
 import java.util.List;
-import java.util.Map;
 
 public class KeyframeAnimation
 {
@@ -11,14 +10,12 @@ public class KeyframeAnimation
 	{
 		for (KeyframeArmature armature : armatures)
 		{
-			for (Map.Entry<String, Bone> entry : armature.bones.entrySet())
+			Bone bone = armature.bones.get(boneName);
+			if (bone != null)
 			{
-				if (entry.getKey().equals(boneName))
+				for (Keyframe keyframe : bone.keyframes)
 				{
-					for (Keyframe keyframe : entry.getValue().keyframes)
-					{
-						keyframe.mirrorRotationYZ();
-					}
+					keyframe.mirrorRotationYZ();
 				}
 			}
 		}

--- a/src/main/java/net/gobbob/mobends/client/ClientProxy.java
+++ b/src/main/java/net/gobbob/mobends/client/ClientProxy.java
@@ -11,8 +11,6 @@ import net.gobbob.mobends.pack.variable.BendsVariable;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.config.Configuration;
-import net.minecraftforge.fml.client.registry.ClientRegistry;
-import net.minecraftforge.fml.common.FMLCommonHandler;
 
 public class ClientProxy extends CommonProxy
 {
@@ -23,8 +21,6 @@ public class ClientProxy extends CommonProxy
 	public void preInit(Configuration config)
 	{
 		preInitCommon(config);
-		
-		MinecraftForge.EVENT_BUS.register(new EntityRenderHandler());
 	}
 
 	public void init(Configuration config)
@@ -34,9 +30,9 @@ public class ClientProxy extends CommonProxy
 		BendsVariable.init();
 		KeyboardHandler.initKeyBindings();
 
-		FMLCommonHandler.instance().bus().register(new EntityRenderHandler());
-		FMLCommonHandler.instance().bus().register(new DataUpdateHandler());
-		FMLCommonHandler.instance().bus().register(new KeyboardHandler());
+		MinecraftForge.EVENT_BUS.register(new EntityRenderHandler());
+		MinecraftForge.EVENT_BUS.register(new DataUpdateHandler());
+		MinecraftForge.EVENT_BUS.register(new KeyboardHandler());
 	}
 
 	public void postInit()

--- a/src/main/java/net/gobbob/mobends/client/event/EntityRenderHandler.java
+++ b/src/main/java/net/gobbob/mobends/client/event/EntityRenderHandler.java
@@ -1,38 +1,22 @@
 package net.gobbob.mobends.client.event;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.HashSet;
 import java.util.UUID;
-
-import org.lwjgl.util.vector.Quaternion;
-import org.lwjgl.util.vector.Vector4f;
 
 import net.gobbob.mobends.animatedentity.AnimatedEntity;
 import net.gobbob.mobends.client.mutators.PlayerMutator;
-import net.gobbob.mobends.client.mutators.ZombieMutator;
-import net.gobbob.mobends.data.BipedEntityData;
 import net.gobbob.mobends.data.EntityData;
 import net.gobbob.mobends.data.EntityDatabase;
 import net.gobbob.mobends.data.PlayerData;
-import net.gobbob.mobends.main.ModConfig;
-import net.gobbob.mobends.util.Color;
-import net.gobbob.mobends.util.Draw;
-import net.gobbob.mobends.util.GLHelper;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.entity.AbstractClientPlayer;
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.entity.Render;
-import net.minecraft.client.renderer.entity.RenderPlayer;
-import net.minecraft.client.renderer.entity.RenderZombie;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
-import net.minecraft.entity.monster.EntityZombie;
-import net.minecraft.entity.player.EntityPlayer;
 import net.minecraftforge.client.event.GuiScreenEvent;
 import net.minecraftforge.client.event.RenderHandEvent;
 import net.minecraftforge.client.event.RenderLivingEvent;
-import net.minecraftforge.client.event.RenderPlayerEvent;
-import net.minecraftforge.fml.common.Mod.EventHandler;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.gameevent.TickEvent;
 
@@ -40,7 +24,7 @@ public class EntityRenderHandler
 {
 	public static float partialTicks;
 	public static boolean renderingGuiScreen = false;
-	public static List<UUID> currentlyRenderedEntities = new ArrayList<UUID>();
+	private HashSet<UUID> currentlyRenderedEntities = new HashSet<>();
 	
 	@SubscribeEvent
 	public void beforeLivingRender(RenderLivingEvent.Pre<? extends EntityLivingBase> event)


### PR DESCRIPTION
EntityRenderHandler was registered both during `preInit` and during `init`.

In EntityRenderHandler, HashSet has have O(1) lookup time rather than the O(n) of an ArrayList
In KeyframeAnimation, iterating through the complete entryset of the HashMap to find a single key defeats the HashMap's purpose.