### PR TITLE
Remove the first type parameter from EntityData classes

### DIFF
--- a/src/main/java/net/gobbob/mobends/core/EntityData.java
+++ b/src/main/java/net/gobbob/mobends/core/EntityData.java
@@ -3,9 +3,6 @@ package net.gobbob.mobends.core;
 import java.util.HashMap;
 import java.util.List;
 
-import org.lwjgl.util.vector.Vector;
-import org.lwjgl.util.vector.Vector3f;
-
 import net.gobbob.mobends.core.animation.controller.Controller;
 import net.gobbob.mobends.core.client.event.DataUpdateHandler;
 import net.gobbob.mobends.core.client.model.IBendsModel;
@@ -16,28 +13,21 @@ import net.minecraft.block.BlockStaticLiquid;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.Minecraft;
 import net.minecraft.entity.Entity;
-import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.MathHelper;
 import net.minecraft.util.math.Vec3d;
 
-public abstract class EntityData<T extends EntityData, E extends Entity> implements IBendsModel
+public abstract class EntityData<E extends Entity> implements IBendsModel
 {
 	protected int entityID;
 	protected E entity;
-	protected Controller<T> controller;
 
-	protected double positionX = 0.0D;
-	protected double positionY = 0.0D;
-	protected double positionZ = 0.0D;
-	protected double prevMotionX = 0.0D;
-	protected double prevMotionY = 0.0D;
-	protected double prevMotionZ = 0.0D;
-	protected double motionX = 0.0D;
-	protected double motionY = 0.0D;
-	protected double motionZ = 0.0D;
+	protected double positionX, positionY, positionZ;
+	protected double prevMotionX, prevMotionY, prevMotionZ;
+	protected double motionX, motionY, motionZ;
 	protected boolean onGround = true;
-	protected HashMap<String, Object> nameToPartMap;
+	protected final HashMap<String, Object> nameToPartMap = new HashMap<>();
 
 	public SmoothVector3f renderOffset;
     public SmoothOrientation renderRotation;
@@ -63,7 +53,6 @@ public abstract class EntityData<T extends EntityData, E extends Entity> impleme
 		this.renderRotation = new SmoothOrientation();
 		this.centerRotation = new SmoothOrientation();
 		
-		this.nameToPartMap = new HashMap<String, Object>();
 		this.nameToPartMap.put("renderRotation", renderRotation);
 		this.nameToPartMap.put("centerRotation", centerRotation);
 	}
@@ -95,8 +84,7 @@ public abstract class EntityData<T extends EntityData, E extends Entity> impleme
 	}
 	
 	/*
-	 * Used by the Previewers to simulate the entities
-	 * being on ground.
+	 * Used by the Previewers to simulate the entities being on ground.
 	 */
 	public void forceOnGround(boolean flag)
 	{
@@ -138,10 +126,7 @@ public abstract class EntityData<T extends EntityData, E extends Entity> impleme
 		return motionX == 0.0D && motionZ == 0.0D;
 	}
 
-	public Controller<T> getController()
-	{
-		return this.controller;
-	}
+	public abstract Controller<?> getController();
 
 	/*
 	 * Called during the render tick in EntityDatabase.updateRender()
@@ -161,78 +146,46 @@ public abstract class EntityData<T extends EntityData, E extends Entity> impleme
 
 	public float getLookAngle()
 	{
-		EntityLivingBase entity = (EntityLivingBase) getEntity();
-		Vec3d vec3 = entity.getLookVec();
-		double x = vec3.x;
-		double z = vec3.z;
-		if (x * x + z * z == 0)
-		{
-			return 0;
-		}
-		return (float) (Math.atan2(x, z) / Math.PI * 180.0f);
+		Vec3d lookVec = this.entity.getLookVec();
+		return (float) GUtil.angleFromCoordinates(lookVec.x, lookVec.z);
+	}
+	
+	private float getWorldMovementAngle() {
+		return (float) GUtil.angleFromCoordinates(this.motionX, this.motionY);
 	}
 
 	public float getMovementAngle()
 	{
-		float lookAngle = this.getLookAngle();
-
-		double x = this.motionX;
-		double z = this.motionZ;
-		if (x * x + z * z == 0)
+		if (isStillHorizontally())
 			return 0;
-		float worldMoveAngle = (float) (Math.atan2(x, z) / Math.PI * 180.0f);
-
-		return worldMoveAngle - lookAngle;
+		return this.getWorldMovementAngle() - this.getLookAngle();
 	}
 	
 	public double getForwardMomentum()
 	{
-		double motionLen = Math.sqrt(this.motionX * this.motionX + this.motionZ * this.motionZ);
-		
-		if (motionLen == 0)
+		if (isStillHorizontally())
 			return 0;
-		
-		double mx = motionX;
-		double mz = motionZ;
-		
-		Vec3d lookVec = entity.getLookVec();
-		Vec3d vec = new Vec3d(lookVec.x, 0, lookVec.z);
-		if (vec.lengthSquared() == 0)
-			return 0;
-		vec = vec.normalize();
-		double lx = vec.x;
-		double lz = vec.z;
-		
-		return lx * mx + lz * mz;
+		Vec3d lookVec = this.entity.getLookVec();
+		Vec3d lookVecHorizontal = new Vec3d(lookVec.x, 0, lookVec.z).normalize();
+		return lookVecHorizontal.x * this.motionX + lookVecHorizontal.z * this.motionZ;
 	}
 	
 	public double getSidewaysMomentum()
 	{
-		double motionLen = Math.sqrt(this.motionX * this.motionX + this.motionZ * this.motionZ);
-		
-		if (motionLen == 0)
+		if (isStillHorizontally())
 			return 0;
-		
-		double mx = motionX;
-		double mz = motionZ;
-		
 		Vec3d rightVec = entity.getLookVec().rotateYaw(-GUtil.PI / 2.0F);
-		Vec3d vec = new Vec3d(rightVec.x, 0, rightVec.z);
-		if (vec.lengthSquared() == 0)
-			return 0;
-		vec = vec.normalize();
-		double lx = vec.x;
-		double lz = vec.z;
-		
-		return lx * mx + lz * mz;
+		Vec3d rightVecHorizontal = new Vec3d(rightVec.x, 0, rightVec.z).normalize();
+		return rightVecHorizontal.x * this.motionX + rightVecHorizontal.z * this.motionZ;
 	}
+	
+	private static final float STRAFING_THRESHOLD = 30.0f;
 
 	public boolean isStrafing()
 	{
 		float angle = this.getMovementAngle();
-		float threshold = 30.0f;
-		return (angle >= threshold && angle <= 180.0f - threshold)
-				|| (angle >= -180.0f + threshold && angle <= -threshold);
+		return (angle >= STRAFING_THRESHOLD && angle <= 180.0f - STRAFING_THRESHOLD)
+				|| (angle >= -180.0f + STRAFING_THRESHOLD && angle <= -STRAFING_THRESHOLD);
 	}
 	
 	/**
@@ -240,11 +193,14 @@ public abstract class EntityData<T extends EntityData, E extends Entity> impleme
 	 */
 	public boolean isUnderwater()
 	{
-		int blockX = (int) this.entity.posX;
-		int blockY = (int) this.entity.posY + 2;
-		int blockZ = (int) this.entity.posZ;
+		if (!this.entity.isInWater())
+			return false;
+		
+		int blockX = MathHelper.floor(this.entity.posX);
+		int blockY = MathHelper.floor(this.entity.posY + 2);
+		int blockZ = MathHelper.floor(this.entity.posZ);
 		IBlockState state = Minecraft.getMinecraft().world.getBlockState(new BlockPos(blockX, blockY, blockZ));
-		return this.entity.isInWater() && state.getBlock() instanceof BlockStaticLiquid;
+		return state.getBlock() instanceof BlockStaticLiquid;
 	}
 
 	public double getPrevMotionMagnitude()
@@ -259,9 +215,7 @@ public abstract class EntityData<T extends EntityData, E extends Entity> impleme
 	
 	public double getInterpolatedMotionMagnitude()
 	{
-		final double magnitude = this.getMotionMagnitude();
-		final double prevMagnitude = this.getPrevMotionMagnitude();
-		return prevMagnitude + (magnitude - prevMagnitude) * DataUpdateHandler.partialTicks;
+		return interpolateMagitude(this.getMotionMagnitude(), this.getPrevMotionMagnitude());
 	}
 	
 	public double getXZMotionMagnitude() {
@@ -274,8 +228,11 @@ public abstract class EntityData<T extends EntityData, E extends Entity> impleme
 	
 	public double getInterpolatedXZMotionMagnitude()
 	{
-		final double magnitude = this.getXZMotionMagnitude();
-		final double prevMagnitude = this.getPrevXZMotionMagnitude();
+		return interpolateMagitude(this.getXZMotionMagnitude(), this.getPrevXZMotionMagnitude());
+	}
+	
+	private static double interpolateMagitude(double magnitude, double prevMagnitude)
+	{
 		return prevMagnitude + (magnitude - prevMagnitude) * DataUpdateHandler.partialTicks;
 	}
 

--- a/src/main/java/net/gobbob/mobends/core/EntityDatabase.java
+++ b/src/main/java/net/gobbob/mobends/core/EntityDatabase.java
@@ -12,69 +12,48 @@ public class EntityDatabase
 	public static EntityDatabase instance = new EntityDatabase();
 
 	// Contains data for all EntityData instances.
-	protected HashMap<Integer, EntityData> entryMap;
+	protected final HashMap<Integer, EntityData<?>> entryMap = new HashMap<>();
 
-	public EntityDatabase()
-	{
-		this.entryMap = new HashMap<Integer, EntityData>();
-	}
-
-	public EntityData get(Integer identifier)
+	public EntityData<?> get(Integer identifier)
 	{
 		return entryMap.get(identifier);
 	}
 
-	public EntityData get(Entity entity)
+	public EntityData<?> get(Entity entity)
 	{
 		return this.get(entity.getEntityId());
 	}
 
 	/*
-	 * If a data instance for that identifier is null, create one. Return the data
-	 * instance for that identifier.
+	 * If a data instance for that identifier is null, create one. 
+	 * 
+	 * 
+	 * @return The data instance for the specified identifier.
 	 */
-	public <T extends EntityData, E extends Entity> T getAndMake(Function<E, T> dataCreationFunction, E entity)
+	public <T extends EntityData<E>, E extends Entity> T getAndMake(Function<E, T> dataCreationFunction, E entity)
 	{
 		final int entityId = entity.getEntityId();
 		
-		T data = null;
-		try
-		{
-			// We try to get and cast the data to the appropriate type.
-			data = (T) this.get(entityId);
-		}
-		catch (ClassCastException e)
-		{
-			// The data that is located inside the database is of the wrong type,
-			// so we remove the old one, and add a new one.
-			this.remove(entityId);
-			data = null;
-		}
+		// Both T and the return type of #get(Entity) will be EntityData during runtime due to generic type erasure. 
+		@SuppressWarnings("unchecked")
+		T data = (T) this.get(entityId);
 		
 		if (data == null)
 		{
 			data = dataCreationFunction.apply(entity);
-			if (data != null)
-			{
-				this.add(entityId, data);
-			}
+			this.add(entityId, data);
 		}
 		return data;
 	}
 
-	private void add(int identifier, EntityData data)
+	private void add(int identifier, EntityData<?> data)
 	{
 		this.entryMap.put(identifier, data);
 	}
 
-	public void add(Entity entity, EntityData data)
+	public void add(Entity entity, EntityData<?> data)
 	{
 		this.add(entity.getEntityId(), data);
-	}
-
-	private void remove(int identifier)
-	{
-		this.entryMap.remove(identifier);
 	}
 
 	public void updateClient()
@@ -83,13 +62,12 @@ public class EntityDatabase
 		while (it.hasNext())
 		{
 			Integer key = it.next();
-			EntityData entityData = get(key);
+			EntityData<?> entityData = get(key);
 			Entity entity = Minecraft.getMinecraft().world.getEntityByID(key);
 			if (entity != null)
 			{
 				if (entityData.getEntity() != entity)
 				{
-					System.out.println("Removing");
 					it.remove();
 				} else
 				{
@@ -98,14 +76,13 @@ public class EntityDatabase
 			} else
 			{
 				it.remove();
-				this.remove(key);
 			}
 		}
 	}
 
 	public void updateRender(float partialTicks)
 	{
-		for (EntityData entityData : this.entryMap.values())
+		for (EntityData<?> entityData : this.entryMap.values())
 		{
 			if (entityData.canBeUpdated())
 				entityData.update(partialTicks);

--- a/src/main/java/net/gobbob/mobends/core/LivingEntityData.java
+++ b/src/main/java/net/gobbob/mobends/core/LivingEntityData.java
@@ -1,23 +1,15 @@
 package net.gobbob.mobends.core;
 
-import java.util.HashMap;
-
-import org.lwjgl.util.vector.Quaternion;
-
 import net.gobbob.mobends.core.client.event.DataUpdateHandler;
-import net.gobbob.mobends.core.client.event.EntityRenderHandler;
-import net.gobbob.mobends.core.util.SmoothOrientation;
-import net.gobbob.mobends.core.util.SmoothVector3f;
 import net.minecraft.block.BlockLadder;
 import net.minecraft.block.state.IBlockState;
-import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.item.EnumAction;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.math.BlockPos;
 
-public abstract class LivingEntityData<T extends LivingEntityData, E extends EntityLivingBase> extends EntityData<T, E>
+public abstract class LivingEntityData<E extends EntityLivingBase> extends EntityData<E>
 {
 	protected float ticksInAir;
     protected float ticksAfterTouchdown;
@@ -110,20 +102,17 @@ public abstract class LivingEntityData<T extends LivingEntityData, E extends Ent
 		}
 			
 		
-		if(this.entity instanceof EntityLivingBase)
+		if(this.entity.swingProgress > 0)
 		{
-			if(((EntityLivingBase)this.entity).swingProgress > 0)
+			if(!this.alreadyPunched)
 			{
-		        if(!this.alreadyPunched)
-		        {
-		        	this.onPunch();
-		        	this.alreadyPunched = true;
-		        }
+				this.onPunch();
+				this.alreadyPunched = true;
 			}
-			else
-			{
-				this.alreadyPunched = false;
-			}
+		}
+		else
+		{
+			this.alreadyPunched = false;
 		}
 		
 		if(this.prevMotionY <= 0.0D && this.motionY > 0.0D)
@@ -167,12 +156,18 @@ public abstract class LivingEntityData<T extends LivingEntityData, E extends Ent
 	
 	public float getClimbingRotation()
 	{
-		EnumFacing facing = getLadderFacing();
-		if(facing == EnumFacing.NORTH) return 0.0f;
-		if(facing == EnumFacing.SOUTH) return 180.0f;
-		if(facing == EnumFacing.WEST) return -90.0f;
-		if(facing == EnumFacing.EAST) return 90.0f;
-		return 0;
+		switch (getLadderFacing()) {
+		case NORTH:
+			return 0f;
+		case SOUTH:
+			return 180f;
+		case WEST:
+			return -90f;
+		case EAST:
+			return 90f;
+		default:
+			return 0;
+		}
 	}
 	
 	public EnumFacing getLadderFacing()
@@ -204,41 +199,46 @@ public abstract class LivingEntityData<T extends LivingEntityData, E extends Ent
 	
 	public float getLedgeHeight()
 	{
-    	float clientY = (float) (entity.posY + (entity.posY-entity.prevPosY) * DataUpdateHandler.partialTicks);
-    	
-    	BlockPos position = new BlockPos(Math.floor(entity.posX), Math.floor(entity.posY), Math.floor(entity.posZ));
-		
+		float clientY = (float) (entity.posY + (entity.posY - entity.prevPosY) * DataUpdateHandler.partialTicks);
+
+		BlockPos position = new BlockPos(Math.floor(entity.posX), Math.floor(entity.posY), Math.floor(entity.posZ));
+
 		IBlockState block = entity.world.getBlockState(position.add(0, 2, 0));
 		IBlockState blockBelow = entity.world.getBlockState(position.add(0, 1, 0));
 		IBlockState blockBelow2 = entity.world.getBlockState(position.add(0, 0, 0));
-    	if(!(block.getBlock() instanceof BlockLadder))
-    	{
-	    	if(!(blockBelow.getBlock() instanceof BlockLadder))
-	    	{
-	    		if(!(blockBelow2.getBlock() instanceof BlockLadder))
-	    			return (float) (clientY-((int)clientY))+2;
-	    		else
-	    			return (float) (clientY-((int)clientY))+1;
-	    	}
-	    	else
-	    		return (float) (clientY-((int)clientY));
-    	}
-    	
-    	return -2.0f;
-    }
+		if (!(block.getBlock() instanceof BlockLadder))
+		{
+			if (!(blockBelow.getBlock() instanceof BlockLadder))
+			{
+				if (!(blockBelow2.getBlock() instanceof BlockLadder))
+					return (float) (clientY - ((int) clientY)) + 2;
+				else
+					return (float) (clientY - ((int) clientY)) + 1;
+			} else
+				return (float) (clientY - ((int) clientY));
+		}
+
+		return -2.0f;
+	}
 	
 	public boolean isDrawingBow()
 	{
-        if (entity.getItemInUseCount() > 0)
-        {
-        	ItemStack itemstack = entity.getHeldItemMainhand();
-            ItemStack itemstack1 = entity.getHeldItemOffhand();
-	        if ((!itemstack.isEmpty() && itemstack.getItemUseAction() == EnumAction.BOW) ||
-	        	(!itemstack1.isEmpty() && itemstack1.getItemUseAction() == EnumAction.BOW))
-	        {
-	        	return true;
-	        }
+		if (entity.getItemInUseCount() > 0)
+		{
+			ItemStack itemstack = entity.getHeldItemMainhand();
+			ItemStack itemstack1 = entity.getHeldItemOffhand();
+			if ((!itemstack.isEmpty() && itemstack.getItemUseAction() == EnumAction.BOW)
+					|| (!itemstack1.isEmpty() && itemstack1.getItemUseAction() == EnumAction.BOW))
+			{
+				return true;
+			}
 		}
-        return false;
+		return false;
+	}
+	
+	@Override
+	public E getEntity()
+	{
+		return this.entity;
 	}
 }

--- a/src/main/java/net/gobbob/mobends/core/addon/AddonHelper.java
+++ b/src/main/java/net/gobbob/mobends/core/addon/AddonHelper.java
@@ -1,7 +1,6 @@
 package net.gobbob.mobends.core.addon;
 
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 
 import net.gobbob.mobends.core.animatedentity.AnimatedEntityRegistry;
@@ -9,6 +8,8 @@ import net.gobbob.mobends.core.animatedentity.AnimatedEntityRegistry;
 public class AddonHelper
 {
 	private static final AddonHelper INSTANCE = new AddonHelper();
+	
+	private AddonHelper() {}
 	
 	private List<IAddon> addons = new ArrayList<IAddon>();
 	

--- a/src/main/java/net/gobbob/mobends/core/addon/IAddon.java
+++ b/src/main/java/net/gobbob/mobends/core/addon/IAddon.java
@@ -4,8 +4,6 @@ import net.gobbob.mobends.core.animatedentity.AnimatedEntityRegistry;
 
 public interface IAddon
 {
-	
 	void registerAnimatedEntities(AnimatedEntityRegistry registry);
 	String getDisplayName();
-	
 }

--- a/src/main/java/net/gobbob/mobends/core/animatedentity/AlterEntry.java
+++ b/src/main/java/net/gobbob/mobends/core/animatedentity/AlterEntry.java
@@ -11,16 +11,12 @@ import net.minecraft.world.World;
 
 public class AlterEntry
 {
-	private String name;
-	private String displayName;
-	public AnimatedEntity owner;
+	private final AnimatedEntity<?> owner;
 	private boolean animate;
 	
-	public AlterEntry(AnimatedEntity owner, String displayName)
+	public AlterEntry(AnimatedEntity<?> owner)
 	{
 		this.owner = owner;
-		this.name = owner.getName();
-		this.displayName = displayName;
 	}
 	
 	public void setAnimate(boolean animate)
@@ -39,14 +35,14 @@ public class AlterEntry
 	}
 	
 	public String getDisplayName() {
-		return this.displayName;
+		return owner.getDisplayName();
 	}
 	
 	public String getName() {
-		return name;
+		return owner.getName();
 	}
 	
-	public AnimatedEntity getOwner() {
+	public AnimatedEntity<?> getOwner() {
 		return owner;
 	}
 	
@@ -57,17 +53,7 @@ public class AlterEntry
 			entity.world = Minecraft.getMinecraft().world;
 			entity.setLocationAndAngles(0, 0, 0, 0, 0);
 			entity.onInitialSpawn(entity.world.getDifficultyForLocation(entity.getPosition()), null);
-		} catch (InstantiationException e) {
-			e.printStackTrace();
-		} catch (IllegalAccessException e) {
-			e.printStackTrace();
-		} catch (IllegalArgumentException e) {
-			e.printStackTrace();
-		} catch (InvocationTargetException e) {
-			e.printStackTrace();
-		} catch (NoSuchMethodException e) {
-			e.printStackTrace();
-		} catch (SecurityException e) {
+		} catch (InstantiationException | IllegalAccessException | IllegalArgumentException | InvocationTargetException | NoSuchMethodException | SecurityException e) {
 			e.printStackTrace();
 		}
 		

--- a/src/main/java/net/gobbob/mobends/core/animatedentity/AnimatedEntity.java
+++ b/src/main/java/net/gobbob/mobends/core/animatedentity/AnimatedEntity.java
@@ -1,37 +1,16 @@
 package net.gobbob.mobends.core.animatedentity;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 
 import net.gobbob.mobends.core.client.MutatedRenderer;
 import net.gobbob.mobends.core.client.mutators.functions.ApplyMutationFunction;
 import net.gobbob.mobends.core.client.mutators.functions.DeapplyMutationFunction;
 import net.gobbob.mobends.core.util.BendsLogger;
-import net.gobbob.mobends.standard.client.mutators.PigZombieMutator;
-import net.gobbob.mobends.standard.client.mutators.PlayerMutator;
-import net.gobbob.mobends.standard.client.mutators.SpiderMutator;
-import net.gobbob.mobends.standard.client.mutators.SquidMutator;
-import net.gobbob.mobends.standard.client.mutators.ZombieMutator;
-import net.gobbob.mobends.standard.client.renderer.entity.RenderBendsArrow;
 import net.gobbob.mobends.standard.client.renderer.entity.RenderBendsSpectralArrow;
 import net.gobbob.mobends.standard.client.renderer.entity.RenderBendsTippedArrow;
-import net.gobbob.mobends.standard.client.renderer.entity.mutated.PlayerRenderer;
-import net.gobbob.mobends.standard.client.renderer.entity.mutated.SpiderRenderer;
-import net.gobbob.mobends.standard.client.renderer.entity.mutated.SquidRenderer;
-import net.gobbob.mobends.standard.client.renderer.entity.mutated.ZombieRenderer;
-import net.gobbob.mobends.standard.previewer.PlayerPreviewer;
-import net.gobbob.mobends.standard.previewer.SpiderPreviewer;
-import net.minecraft.client.Minecraft;
-import net.minecraft.client.entity.AbstractClientPlayer;
 import net.minecraft.client.renderer.entity.RenderLivingBase;
-import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
-import net.minecraft.entity.monster.EntityPigZombie;
-import net.minecraft.entity.monster.EntitySpider;
-import net.minecraft.entity.monster.EntityZombie;
-import net.minecraft.entity.passive.EntitySquid;
-import net.minecraft.entity.projectile.EntityArrow;
 import net.minecraft.entity.projectile.EntitySpectralArrow;
 import net.minecraft.entity.projectile.EntityTippedArrow;
 import net.minecraftforge.common.config.Configuration;
@@ -39,22 +18,22 @@ import net.minecraftforge.fml.client.registry.RenderingRegistry;
 
 public class AnimatedEntity<T extends EntityLivingBase>
 {
-	String name;
-	String displayName;
+	final String name;
+	final String displayName;
 	List<AlterEntry> alterEntries = new ArrayList<AlterEntry>();
 	private String[] alterableParts;
 	private MutatedRenderer<T> renderer;
 
-	public Class<? extends Entity> entityClass;
+	public final Class<T> entityClass;
 	private final ApplyMutationFunction applyMutation;
 	private final DeapplyMutationFunction deapplyMutation;
 	private final Runnable refreshMutation;
 
-	public Previewer previewer;
+	public Previewer<T> previewer;
 
-	public AnimatedEntity(String id, String displayName, Class<? extends Entity> entityClass,
+	public AnimatedEntity(String id, String displayName, Class<T> entityClass,
 			ApplyMutationFunction applyMutation, DeapplyMutationFunction deapplyMutation, Runnable refreshMutation,
-			MutatedRenderer renderer, String[] alterableParts)
+			MutatedRenderer<T> renderer, String[] alterableParts)
 	{
 		this.name = id;
 		this.displayName = displayName;
@@ -64,7 +43,7 @@ public class AnimatedEntity<T extends EntityLivingBase>
 		this.refreshMutation = refreshMutation;
 		this.renderer = renderer;
 		this.alterableParts = alterableParts;
-		this.addAlterEntry(new AlterEntry(this, displayName));
+		this.addAlterEntry(new AlterEntry(this));
 	}
 
 	public List<AlterEntry> getAlredEntries()
@@ -92,7 +71,7 @@ public class AnimatedEntity<T extends EntityLivingBase>
 		return name;
 	}
 
-	public Previewer getPreviewer()
+	public Previewer<T> getPreviewer()
 	{
 		return this.previewer;
 	}
@@ -110,13 +89,13 @@ public class AnimatedEntity<T extends EntityLivingBase>
 		return false;
 	}
 
-	public AnimatedEntity addAlterEntry(AlterEntry alterEntry)
+	public AnimatedEntity<T> addAlterEntry(AlterEntry alterEntry)
 	{
 		this.alterEntries.add(alterEntry);
 		return this;
 	}
 
-	public AnimatedEntity setPreviewer(Previewer previewer)
+	public AnimatedEntity<T> setPreviewer(Previewer<T> previewer)
 	{
 		this.previewer = previewer;
 		return this;
@@ -193,9 +172,9 @@ public class AnimatedEntity<T extends EntityLivingBase>
 		 */
 	}
 
-	public static AnimatedEntity getForEntity(Entity entity)
+	public static <E extends EntityLivingBase> AnimatedEntity<E> getForEntity(E entity)
 	{
-		return AnimatedEntityRegistry.getForEntity(entity);
+		return (AnimatedEntity<E>) AnimatedEntityRegistry.getForEntity(entity);
 	}
 	
 	public static void refreshMutators()

--- a/src/main/java/net/gobbob/mobends/core/animatedentity/AnimatedEntity.java
+++ b/src/main/java/net/gobbob/mobends/core/animatedentity/AnimatedEntity.java
@@ -46,7 +46,7 @@ public class AnimatedEntity<T extends EntityLivingBase>
 		this.addAlterEntry(new AlterEntry(this));
 	}
 
-	public List<AlterEntry> getAlredEntries()
+	public List<AlterEntry> getAlterEntries()
 	{
 		return this.alterEntries;
 	}

--- a/src/main/java/net/gobbob/mobends/core/animatedentity/AnimatedEntityRegistry.java
+++ b/src/main/java/net/gobbob/mobends/core/animatedentity/AnimatedEntityRegistry.java
@@ -8,7 +8,9 @@ import net.minecraftforge.common.config.Configuration;
 
 public class AnimatedEntityRegistry
 {
-	public static AnimatedEntityRegistry INSTANCE = new AnimatedEntityRegistry();
+	public static final AnimatedEntityRegistry INSTANCE = new AnimatedEntityRegistry();
+	
+	private AnimatedEntityRegistry() {}
 	
 	private HashMap<String, AnimatedEntity<?>> animatedEntities = new HashMap<String, AnimatedEntity<?>>();
 
@@ -34,21 +36,21 @@ public class AnimatedEntityRegistry
 		return INSTANCE.animatedEntities.values();
 	}
 	
-	public static AnimatedEntity get(String name)
+	public static AnimatedEntity<?> get(String name)
 	{
 		return INSTANCE.animatedEntities.get(name);
 	}
 	
-	public static AnimatedEntity getForEntity(Entity entity)
+	public static AnimatedEntity<?> getForEntity(Entity entity)
 	{
 		// Checking direct registration
 		Class<? extends Entity> entityClass = entity.getClass();
-		for (AnimatedEntity animatedEntity : INSTANCE.animatedEntities.values())
+		for (AnimatedEntity<?> animatedEntity : INSTANCE.animatedEntities.values())
 			if (animatedEntity.entityClass.equals(entityClass))
 				return animatedEntity;
 
 		// Checking indirect inheritance
-		for (AnimatedEntity animatedEntity : INSTANCE.animatedEntities.values())
+		for (AnimatedEntity<?> animatedEntity : INSTANCE.animatedEntities.values())
 			if (animatedEntity.entityClass.isInstance(entity))
 				return animatedEntity;
 
@@ -57,7 +59,7 @@ public class AnimatedEntityRegistry
 	
 	public static void refreshMutators()
 	{
-		for (AnimatedEntity animatedEntity : INSTANCE.animatedEntities.values())
+		for (AnimatedEntity<?> animatedEntity : INSTANCE.animatedEntities.values())
 			animatedEntity.refreshMutation();
 	}
 }

--- a/src/main/java/net/gobbob/mobends/core/animation/bit/AnimationBit.java
+++ b/src/main/java/net/gobbob/mobends/core/animation/bit/AnimationBit.java
@@ -3,7 +3,7 @@ package net.gobbob.mobends.core.animation.bit;
 import net.gobbob.mobends.core.EntityData;
 import net.gobbob.mobends.core.animation.layer.AnimationLayer;
 
-public abstract class AnimationBit<T extends EntityData>
+public abstract class AnimationBit<T extends EntityData<?>>
 {
 	/*
 	 * The layer that this bit is performed by.

--- a/src/main/java/net/gobbob/mobends/core/animation/bit/KeyframeAnimationBit.java
+++ b/src/main/java/net/gobbob/mobends/core/animation/bit/KeyframeAnimationBit.java
@@ -11,7 +11,7 @@ import net.gobbob.mobends.core.animation.keyframe.KeyframeArmature;
 import net.gobbob.mobends.core.client.event.DataUpdateHandler;
 import net.gobbob.mobends.core.client.model.IModelPart;
 
-public class KeyframeAnimationBit<T extends EntityData> extends AnimationBit<T>
+public class KeyframeAnimationBit<T extends EntityData<?>> extends AnimationBit<T>
 {
 	protected KeyframeAnimation performedAnimation;
 	private ArmatureMask mask;

--- a/src/main/java/net/gobbob/mobends/core/animation/controller/Controller.java
+++ b/src/main/java/net/gobbob/mobends/core/animation/controller/Controller.java
@@ -9,7 +9,7 @@ import net.gobbob.mobends.core.EntityData;
  * It's a member of an EntityData instance, and it holds all
  * the information about the current animation's state.
  * */
-public abstract class Controller<T extends EntityData>
+public abstract class Controller<T extends EntityData<?>>
 {
 	public abstract void perform(T entityData);
 }

--- a/src/main/java/net/gobbob/mobends/core/animation/keyframe/KeyframeArmature.java
+++ b/src/main/java/net/gobbob/mobends/core/animation/keyframe/KeyframeArmature.java
@@ -1,6 +1,5 @@
 package net.gobbob.mobends.core.animation.keyframe;
 
-import java.util.List;
 import java.util.Map;
 
 public class KeyframeArmature

--- a/src/main/java/net/gobbob/mobends/core/animation/layer/AnimationLayer.java
+++ b/src/main/java/net/gobbob/mobends/core/animation/layer/AnimationLayer.java
@@ -5,7 +5,7 @@ import java.util.Collection;
 
 import net.gobbob.mobends.core.EntityData;
 
-public abstract class AnimationLayer<T extends EntityData>
+public abstract class AnimationLayer<T extends EntityData<?>>
 {
 	/**
 	 * Returns the actions currently being performed

--- a/src/main/java/net/gobbob/mobends/core/animation/layer/HardAnimationLayer.java
+++ b/src/main/java/net/gobbob/mobends/core/animation/layer/HardAnimationLayer.java
@@ -3,10 +3,11 @@ package net.gobbob.mobends.core.animation.layer;
 import net.gobbob.mobends.core.EntityData;
 import net.gobbob.mobends.core.animation.bit.AnimationBit;
 
-public class HardAnimationLayer<T extends EntityData> extends AnimationLayer<T>
+public class HardAnimationLayer<T extends EntityData<?>> extends AnimationLayer<T>
 {
 	protected AnimationBit<T> performedBit, previousBit;
 	
+	@SuppressWarnings("unchecked")
 	public void playBit(AnimationBit<? extends T> bit, T entityData)
 	{
 		this.previousBit = this.performedBit;

--- a/src/main/java/net/gobbob/mobends/core/animation/layer/KeyframeAnimationLayer.java
+++ b/src/main/java/net/gobbob/mobends/core/animation/layer/KeyframeAnimationLayer.java
@@ -2,32 +2,25 @@ package net.gobbob.mobends.core.animation.layer;
 
 import java.util.Map;
 
-import org.lwjgl.util.vector.Vector3f;
-
 import net.gobbob.mobends.core.EntityData;
-import net.gobbob.mobends.core.animation.bit.AnimationBit;
 import net.gobbob.mobends.core.animation.keyframe.Bone;
 import net.gobbob.mobends.core.animation.keyframe.Keyframe;
 import net.gobbob.mobends.core.animation.keyframe.KeyframeAnimation;
 import net.gobbob.mobends.core.animation.keyframe.KeyframeArmature;
 import net.gobbob.mobends.core.client.event.DataUpdateHandler;
 import net.gobbob.mobends.core.client.model.IModelPart;
-import net.gobbob.mobends.core.pack.BendsAction.EnumBoxProperty;
-import net.gobbob.mobends.core.util.EnumAxis;
-import net.gobbob.mobends.core.util.Quaternion;
-import net.gobbob.mobends.core.util.SmoothOrientation;
 
-public class KeyframeAnimationLayer<DataType extends EntityData> extends AnimationLayer<DataType>
+public class KeyframeAnimationLayer<T extends EntityData<?>> extends AnimationLayer<T>
 {
 	public KeyframeAnimation performedAnimation;
 	public float keyframeIndex = 0;
 	
-	public void playBit(KeyframeAnimation animation, DataType entityData)
+	public void playBit(KeyframeAnimation animation, T entityData)
 	{
 		this.performedAnimation = animation;
 	}
 	
-	public void playOrContinueBit(KeyframeAnimation animation, DataType entityData)
+	public void playOrContinueBit(KeyframeAnimation animation, T entityData)
 	{
 		if (!this.isPlaying(animation))
 			this.playBit(animation, entityData);
@@ -54,13 +47,13 @@ public class KeyframeAnimationLayer<DataType extends EntityData> extends Animati
 	}
 	
 	@Override
-	public String[] getActions(EntityData entityData)
+	public String[] getActions(T entityData)
 	{
 		return null;
 	}
 	
 	@Override
-	public void perform(EntityData entityData)
+	public void perform(T entityData)
 	{
 		int minKeyframes = Integer.MAX_VALUE;
 		

--- a/src/main/java/net/gobbob/mobends/core/client/MutatedRenderer.java
+++ b/src/main/java/net/gobbob/mobends/core/client/MutatedRenderer.java
@@ -3,7 +3,6 @@ package net.gobbob.mobends.core.client;
 import net.gobbob.mobends.core.EntityData;
 import net.gobbob.mobends.core.EntityDatabase;
 import net.gobbob.mobends.core.LivingEntityData;
-import net.gobbob.mobends.core.main.ModConfig;
 import net.gobbob.mobends.core.util.GLHelper;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.GlStateManager;
@@ -33,14 +32,14 @@ public abstract class MutatedRenderer<T extends EntityLivingBase>
 			viewZ = viewEntity.prevPosZ + (viewEntity.posZ - viewEntity.prevPosZ) * partialTicks;
 		}
 		GlStateManager.translate(entityX - viewX, entityY - viewY, entityZ - viewZ);
-		GlStateManager.rotate(-this.interpolateRotation(entity.prevRenderYawOffset, entity.renderYawOffset, partialTicks), 0F, 1F, 0F);
+		GlStateManager.rotate(-interpolateRotation(entity.prevRenderYawOffset, entity.renderYawOffset, partialTicks), 0F, 1F, 0F);
 		
 		this.renderLocalAccessories(entity, partialTicks);
 		
-		EntityData data = EntityDatabase.instance.get(entity);
+		EntityData<?> data = EntityDatabase.instance.get(entity);
 		if (data != null && data instanceof LivingEntityData)
 		{
-			LivingEntityData livingData = (LivingEntityData) data;
+			LivingEntityData<?> livingData = (LivingEntityData<?>) data;
 
 			GlStateManager.translate(livingData.renderOffset.getX() * scale,
 									 livingData.renderOffset.getY() * scale,
@@ -53,7 +52,7 @@ public abstract class MutatedRenderer<T extends EntityLivingBase>
 		
 		this.transformLocally(entity, partialTicks);
 		
-		GlStateManager.rotate(this.interpolateRotation(entity.prevRenderYawOffset, entity.renderYawOffset, partialTicks), 0F, 1F, 0F);
+		GlStateManager.rotate(interpolateRotation(entity.prevRenderYawOffset, entity.renderYawOffset, partialTicks), 0F, 1F, 0F);
 		GlStateManager.translate(viewX - entityX, viewY - entityY, viewZ - entityZ);
 	}
 	

--- a/src/main/java/net/gobbob/mobends/core/client/event/EntityRenderHandler.java
+++ b/src/main/java/net/gobbob/mobends/core/client/event/EntityRenderHandler.java
@@ -3,12 +3,10 @@ package net.gobbob.mobends.core.client.event;
 import java.util.HashSet;
 import java.util.UUID;
 
-import net.gobbob.mobends.core.EntityData;
-import net.gobbob.mobends.core.EntityDatabase;
 import net.gobbob.mobends.core.animatedentity.AnimatedEntity;
 import net.gobbob.mobends.standard.client.mutators.PlayerMutator;
-import net.gobbob.mobends.standard.data.PlayerData;
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.entity.AbstractClientPlayer;
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.entity.Render;
 import net.minecraft.entity.Entity;
@@ -17,7 +15,6 @@ import net.minecraftforge.client.event.GuiScreenEvent;
 import net.minecraftforge.client.event.RenderHandEvent;
 import net.minecraftforge.client.event.RenderLivingEvent;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
-import net.minecraftforge.fml.common.gameevent.TickEvent;
 
 public class EntityRenderHandler
 {
@@ -27,7 +24,7 @@ public class EntityRenderHandler
 	@SubscribeEvent
 	public void beforeLivingRender(RenderLivingEvent.Pre<? extends EntityLivingBase> event)
 	{
-		AnimatedEntity animatedEntity = AnimatedEntity.getForEntity(event.getEntity());
+		AnimatedEntity<EntityLivingBase> animatedEntity = AnimatedEntity.getForEntity(event.getEntity());
 		if (animatedEntity == null)
 			return;
 		
@@ -55,7 +52,7 @@ public class EntityRenderHandler
 	@SubscribeEvent
 	public void afterLivingRender(RenderLivingEvent.Post<? extends EntityLivingBase> event)
 	{
-		AnimatedEntity animatedEntity = AnimatedEntity.getForEntity(event.getEntity());
+		AnimatedEntity<EntityLivingBase> animatedEntity = AnimatedEntity.getForEntity(event.getEntity());
 		if (animatedEntity == null)
 			return;
 
@@ -86,10 +83,12 @@ public class EntityRenderHandler
 	{
 		Minecraft mc = Minecraft.getMinecraft();
 		Entity viewEntity = mc.getRenderViewEntity();
-		AnimatedEntity animatedEntity = AnimatedEntity.getForEntity(viewEntity);
-		EntityData entityData = EntityDatabase.instance.get(viewEntity);
+		if (!(viewEntity instanceof AbstractClientPlayer))
+			return;
+		AbstractClientPlayer player = (AbstractClientPlayer) viewEntity;
+		AnimatedEntity<AbstractClientPlayer> animatedEntity = AnimatedEntity.getForEntity(player);
 		
-		if (animatedEntity != null && animatedEntity.isAnimated() && entityData instanceof PlayerData)
+		if (animatedEntity != null && animatedEntity.isAnimated())
 		{
 			Render<Entity> render = mc.getRenderManager().getEntityRenderObject(viewEntity);
 			PlayerMutator mutator = PlayerMutator.getMutatorForRenderer(render);

--- a/src/main/java/net/gobbob/mobends/core/client/gui/GuiBendsMenu.java
+++ b/src/main/java/net/gobbob/mobends/core/client/gui/GuiBendsMenu.java
@@ -85,7 +85,7 @@ public class GuiBendsMenu extends GuiScreen
 
 		for (AnimatedEntity animatedEntity : AnimatedEntityRegistry.getRegistered())
 		{
-			this.alterEntries.addAll(animatedEntity.getAlredEntries());
+			this.alterEntries.addAll(animatedEntity.getAlterEntries());
 		}
 
 		this.customizeButton = new GuiSectionButton(Lang.format("mobends.gui.section.customize"), 0xFFDA3A00)

--- a/src/main/java/net/gobbob/mobends/core/client/model/entity/armor/ModelBipedArmorCustom.java
+++ b/src/main/java/net/gobbob/mobends/core/client/model/entity/armor/ModelBipedArmorCustom.java
@@ -2,7 +2,6 @@ package net.gobbob.mobends.core.client.model.entity.armor;
 
 import java.lang.reflect.Field;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -20,7 +19,6 @@ import net.gobbob.mobends.core.client.model.ModelPartTransform;
 import net.gobbob.mobends.core.util.ModelUtils;
 import net.gobbob.mobends.standard.client.mutators.BoxMutator;
 import net.gobbob.mobends.standard.data.BipedEntityData;
-import net.minecraft.client.entity.AbstractClientPlayer;
 import net.minecraft.client.model.ModelBiped;
 import net.minecraft.client.model.ModelRenderer;
 import net.minecraft.client.renderer.GlStateManager;
@@ -51,7 +49,7 @@ public class ModelBipedArmorCustom extends ModelBiped
 	/*
 	 * The lastest AnimatedEntity that rendered this armor.
 	 */
-	protected AnimatedEntity lastAnimatedEntity;
+	protected AnimatedEntity<EntityLivingBase> lastAnimatedEntity;
 	
 	/*
 	 * This is used as a parent for other parts, like the arms and head.
@@ -94,9 +92,15 @@ public class ModelBipedArmorCustom extends ModelBiped
 	{
 		this.setRotationAngles(limbSwing, limbSwingAmount, ageInTicks, netHeadYaw, headPitch, scale, entityIn);
 
-		AnimatedEntity animatedEntity = AnimatedEntity.getForEntity(entityIn);
-		EntityData entityData = EntityDatabase.instance.get(entityIn.getEntityId());
-		if (animatedEntity == null || entityData == null || !(entityData instanceof BipedEntityData))
+		if (!(entityIn instanceof EntityLivingBase))
+			return;
+		EntityLivingBase entityLiving = (EntityLivingBase) entityIn;
+		
+		AnimatedEntity<EntityLivingBase> animatedEntity = AnimatedEntity.getForEntity(entityLiving);
+		if (animatedEntity == null)
+			return;
+		EntityData<?> entityData = EntityDatabase.instance.get(entityIn.getEntityId());
+		if (entityData == null || !(entityData instanceof BipedEntityData))
 			return;
 
 		lastAnimatedEntity = animatedEntity;
@@ -109,7 +113,7 @@ public class ModelBipedArmorCustom extends ModelBiped
 			this.demutate();
 		}
 		
-		BipedEntityData dataBiped = (BipedEntityData) entityData;
+		BipedEntityData<?> dataBiped = (BipedEntityData<?>) entityData;
 		
 		GlStateManager.pushMatrix();
 		original.render(entityIn, limbSwing, limbSwingAmount, ageInTicks, netHeadYaw, headPitch, scale);
@@ -173,11 +177,11 @@ public class ModelBipedArmorCustom extends ModelBiped
 	{
 		original.setModelAttributes(this);
 
-		EntityData entityData = EntityDatabase.instance.get(entityIn.getEntityId());
+		EntityData<?> entityData = EntityDatabase.instance.get(entityIn.getEntityId());
 		if (entityData == null || !(entityData instanceof BipedEntityData))
 			return;
 
-		BipedEntityData dataBiped = (BipedEntityData) entityData;
+		BipedEntityData<?> dataBiped = (BipedEntityData<?>) entityData;
 
 		this.mainBodyTransform.syncUp(dataBiped.body);
 		

--- a/src/main/java/net/gobbob/mobends/core/configuration/ModConfiguration.java
+++ b/src/main/java/net/gobbob/mobends/core/configuration/ModConfiguration.java
@@ -31,7 +31,7 @@ public class ModConfiguration
     	config.load();
     	
     	for(AnimatedEntity animatedEntity : AnimatedEntityRegistry.getRegistered()) {
-    		List<AlterEntry> alterEntries = animatedEntity.getAlredEntries();
+    		List<AlterEntry> alterEntries = animatedEntity.getAlterEntries();
     		for(int a = 0; a < alterEntries.size(); a++) {
     			config.get("Animated", alterEntries.get(a).getName(), true).setValue(alterEntries.get(a).isAnimated());
     		}

--- a/src/main/java/net/gobbob/mobends/core/util/Draw.java
+++ b/src/main/java/net/gobbob/mobends/core/util/Draw.java
@@ -7,7 +7,6 @@ import net.minecraft.client.renderer.BufferBuilder;
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.client.renderer.vertex.DefaultVertexFormats;
-import net.minecraft.client.renderer.vertex.VertexBuffer;
 
 public class Draw {
 	public static void rectangle(float x, float y, float w, float h){

--- a/src/main/java/net/gobbob/mobends/core/util/GUtil.java
+++ b/src/main/java/net/gobbob/mobends/core/util/GUtil.java
@@ -12,8 +12,6 @@ import java.util.List;
 
 import org.lwjgl.util.vector.Vector3f;
 
-import net.gobbob.mobends.core.pack.PackManager;
-import net.gobbob.mobends.core.pack.BPDFile.Entry;
 import net.minecraft.client.gui.FontRenderer;
 
 public class GUtil
@@ -28,6 +26,11 @@ public class GUtil
 	public static int clamp(int value, int min, int max)
 	{
 		return Math.min(Math.max(value, min), max);
+	}
+	
+	public static double angleFromCoordinates(double x, double z)
+	{
+		return Math.atan2(x, z) / Math.PI * 180.0;
 	}
 	
 	public static Vector3 translate(Vector3 vector, float x, float y, float z)

--- a/src/main/java/net/gobbob/mobends/standard/DefaultAddon.java
+++ b/src/main/java/net/gobbob/mobends/standard/DefaultAddon.java
@@ -34,22 +34,22 @@ public class DefaultAddon implements IAddon
 
 		registry.registerEntity(new AnimatedEntity<EntityPigZombie>("pig_zombie", "Zombie Pigman", EntityPigZombie.class,
 						PigZombieMutator::apply, PigZombieMutator::deapply, PigZombieMutator::refresh,
-						new ZombieRenderer(), new String[] { "head", "body", "leftArm", "rightArm", "leftForeArm",
+						new ZombieRenderer<EntityPigZombie>(), new String[] { "head", "body", "leftArm", "rightArm", "leftForeArm",
 								"rightForeArm", "leftLeg", "rightLeg", "leftForeLeg", "rightForeLeg" }));
 
 		registry.registerEntity(new AnimatedEntity<EntityZombie>("zombie", "Zombie", EntityZombie.class, ZombieMutator::apply,
-						ZombieMutator::deapply, ZombieMutator::refresh, new ZombieRenderer(),
+						ZombieMutator::deapply, ZombieMutator::refresh, new ZombieRenderer<EntityZombie>(),
 						new String[] { "head", "body", "leftArm", "rightArm", "leftForeArm", "rightForeArm", "leftLeg",
 								"rightLeg", "leftForeLeg", "rightForeLeg" }));
 
 		registry.registerEntity(new AnimatedEntity<EntitySpider>("spider", "Spider", EntitySpider.class, SpiderMutator::apply,
-						SpiderMutator::deapply, SpiderMutator::refresh, new SpiderRenderer(),
+						SpiderMutator::deapply, SpiderMutator::refresh, new SpiderRenderer<EntitySpider>(),
 						new String[] { "head", "body", "neck", "leg1", "leg2", "leg3", "leg4", "leg5", "leg6", "leg7",
 								"leg8", "foreLeg1", "foreLeg2", "foreLeg3", "foreLeg4", "foreLeg5", "foreLeg6",
 								"foreLeg7", "foreLeg8" }).setPreviewer(new SpiderPreviewer()));
 
 		registry.registerEntity(new AnimatedEntity<EntitySquid>("squid", "Squid", EntitySquid.class, SquidMutator::apply,
-						SquidMutator::deapply, SquidMutator::refresh, new SquidRenderer(),
+						SquidMutator::deapply, SquidMutator::refresh, new SquidRenderer<EntitySquid>(),
 						new String[] { "body", "tentacle1", "tentacle2", "tentacle3", "tentacle4", "tentacle5", "tentacle6",
 								"tentacle7", "tentacle8" }));
 	}

--- a/src/main/java/net/gobbob/mobends/standard/animation/bit/biped/AttackSlashDownAnimationBit.java
+++ b/src/main/java/net/gobbob/mobends/standard/animation/bit/biped/AttackSlashDownAnimationBit.java
@@ -20,20 +20,20 @@ import net.minecraft.util.EnumHand;
 import net.minecraft.util.EnumHandSide;
 import net.minecraft.util.math.MathHelper;
 
-public class AttackSlashDownAnimationBit extends AnimationBit<BipedEntityData<?, ?>>
+public class AttackSlashDownAnimationBit extends AnimationBit<BipedEntityData<?>>
 {
 	private static final String[] ACTIONS = new String[] { "attack", "attack_1" };
 	
 	private float ticksPlayed;
 	
 	@Override
-	public String[] getActions(BipedEntityData entityData)
+	public String[] getActions(BipedEntityData<?> entityData)
 	{
 		return ACTIONS;
 	}
 
 	@Override
-	public void onPlay(BipedEntityData data)
+	public void onPlay(BipedEntityData<?> data)
 	{
 		data.swordTrail.reset();
 		
@@ -41,7 +41,7 @@ public class AttackSlashDownAnimationBit extends AnimationBit<BipedEntityData<?,
 	}
 
 	@Override
-	public void perform(BipedEntityData data)
+	public void perform(BipedEntityData<?> data)
 	{
 		EntityLivingBase living = data.getEntity();
 		EnumHandSide primaryHand = living.getPrimaryHand();

--- a/src/main/java/net/gobbob/mobends/standard/animation/bit/biped/AttackSlashUpAnimationBit.java
+++ b/src/main/java/net/gobbob/mobends/standard/animation/bit/biped/AttackSlashUpAnimationBit.java
@@ -15,24 +15,24 @@ import net.minecraft.util.EnumHand;
 import net.minecraft.util.EnumHandSide;
 import net.minecraft.util.math.MathHelper;
 
-public class AttackSlashUpAnimationBit extends AnimationBit<BipedEntityData<?, ?>>
+public class AttackSlashUpAnimationBit extends AnimationBit<BipedEntityData<?>>
 {
 	private static final String[] ACTIONS = new String[] { "attack", "attack_0" };
 	
 	@Override
-	public String[] getActions(BipedEntityData<?, ?> entityData)
+	public String[] getActions(BipedEntityData<?> entityData)
 	{
 		return ACTIONS;
 	}
 	
 	@Override
-	public void onPlay(BipedEntityData<?, ?> data)
+	public void onPlay(BipedEntityData<?> data)
 	{
 		data.swordTrail.reset();
 	}
 	
 	@Override
-	public void perform(BipedEntityData<?, ?> data)
+	public void perform(BipedEntityData<?> data)
 	{
 		EntityLivingBase living = data.getEntity();
 		EnumHandSide primaryHand = living.getPrimaryHand();

--- a/src/main/java/net/gobbob/mobends/standard/animation/bit/biped/AttackStanceSprintAnimationBit.java
+++ b/src/main/java/net/gobbob/mobends/standard/animation/bit/biped/AttackStanceSprintAnimationBit.java
@@ -9,18 +9,18 @@ import net.minecraft.item.ItemSword;
 import net.minecraft.util.EnumHand;
 import net.minecraft.util.EnumHandSide;
 
-public class AttackStanceSprintAnimationBit extends AnimationBit<BipedEntityData<?, ?>>
+public class AttackStanceSprintAnimationBit extends AnimationBit<BipedEntityData<?>>
 {
 	private static final String[] ACTIONS = new String[] { "attack_stance_sprint" };
 	
 	@Override
-	public String[] getActions(BipedEntityData<?, ?> entityData)
+	public String[] getActions(BipedEntityData<?> entityData)
 	{
 		return ACTIONS;
 	}
 
 	@Override
-	public void perform(BipedEntityData<?, ?> data)
+	public void perform(BipedEntityData<?> data)
 	{
 		EntityLivingBase living = data.getEntity();
 		EnumHandSide primaryHand = living.getPrimaryHand();

--- a/src/main/java/net/gobbob/mobends/standard/animation/bit/biped/AttackWhirlSlashAnimationBit.java
+++ b/src/main/java/net/gobbob/mobends/standard/animation/bit/biped/AttackWhirlSlashAnimationBit.java
@@ -13,18 +13,18 @@ import net.minecraft.util.EnumHand;
 import net.minecraft.util.EnumHandSide;
 import net.minecraft.util.math.MathHelper;
 
-public class AttackWhirlSlashAnimationBit extends AnimationBit<BipedEntityData<?, ?>>
+public class AttackWhirlSlashAnimationBit extends AnimationBit<BipedEntityData<?>>
 {
 	private static final String[] ACTIONS = new String[] { "attack", "attack_2" };
 	
 	@Override
-	public String[] getActions(BipedEntityData<?, ?> entityData)
+	public String[] getActions(BipedEntityData<?> entityData)
 	{
 		return ACTIONS;
 	}
 
 	@Override
-	public void perform(BipedEntityData<?, ?> data)
+	public void perform(BipedEntityData<?> data)
 	{
 		EntityLivingBase living = data.getEntity();
 		EnumHandSide primaryHand = living.getPrimaryHand();

--- a/src/main/java/net/gobbob/mobends/standard/animation/bit/biped/BowAnimationBit.java
+++ b/src/main/java/net/gobbob/mobends/standard/animation/bit/biped/BowAnimationBit.java
@@ -7,14 +7,14 @@ import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.util.EnumHandSide;
 import net.minecraft.util.math.MathHelper;
 
-public class BowAnimationBit extends AnimationBit<BipedEntityData<?, ?>>
+public class BowAnimationBit extends AnimationBit<BipedEntityData<?>>
 {
 	private static final String[] ACTIONS = new String[] { "bow" };
 	
 	protected EnumHandSide actionHand = EnumHandSide.RIGHT;
 	
 	@Override
-	public String[] getActions(BipedEntityData<?, ?> entityData)
+	public String[] getActions(BipedEntityData<?> entityData)
 	{
 		return ACTIONS;
 	}
@@ -25,7 +25,7 @@ public class BowAnimationBit extends AnimationBit<BipedEntityData<?, ?>>
 	}
 	
 	@Override
-	public void perform(BipedEntityData<?, ?> data)
+	public void perform(BipedEntityData<?> data)
 	{
 		EntityLivingBase living = data.getEntity();
 

--- a/src/main/java/net/gobbob/mobends/standard/animation/bit/biped/BreakingAnimationBit.java
+++ b/src/main/java/net/gobbob/mobends/standard/animation/bit/biped/BreakingAnimationBit.java
@@ -4,12 +4,12 @@ import net.gobbob.mobends.core.animation.bit.KeyframeAnimationBit;
 import net.gobbob.mobends.core.animation.keyframe.AnimationLoader;
 import net.gobbob.mobends.standard.data.BipedEntityData;
 
-public class BreakingAnimationBit extends KeyframeAnimationBit<BipedEntityData<?, ?>>
+public class BreakingAnimationBit extends KeyframeAnimationBit<BipedEntityData<?>>
 {
 	private static final String[] ACTIONS = new String[] { "breaking" };
 	
 	@Override
-	public String[] getActions(BipedEntityData<?, ?> entityData)
+	public String[] getActions(BipedEntityData<?> entityData)
 	{
 		return ACTIONS;
 	}
@@ -21,7 +21,7 @@ public class BreakingAnimationBit extends KeyframeAnimationBit<BipedEntityData<?
 	}
 	
 	@Override
-	public void perform(BipedEntityData<?, ?> data)
+	public void perform(BipedEntityData<?> data)
 	{
 		super.perform(data);
 		

--- a/src/main/java/net/gobbob/mobends/standard/animation/bit/biped/EatingAnimationBit.java
+++ b/src/main/java/net/gobbob/mobends/standard/animation/bit/biped/EatingAnimationBit.java
@@ -11,7 +11,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.util.EnumHandSide;
 import net.minecraft.util.math.MathHelper;
 
-public class EatingAnimationBit extends AnimationBit<BipedEntityData<?, ?>>
+public class EatingAnimationBit extends AnimationBit<BipedEntityData<?>>
 {
 	private static final String[] ACTIONS = new String[] { "eating" };
 	
@@ -20,7 +20,7 @@ public class EatingAnimationBit extends AnimationBit<BipedEntityData<?, ?>>
 	protected float bringUpAnimation;
 	
 	@Override
-	public String[] getActions(BipedEntityData<?, ?> data)
+	public String[] getActions(BipedEntityData<?> data)
 	{
 		return ACTIONS;
 	}
@@ -31,13 +31,13 @@ public class EatingAnimationBit extends AnimationBit<BipedEntityData<?, ?>>
 	}
 	
 	@Override
-	public void onPlay(BipedEntityData<?, ?> data)
+	public void onPlay(BipedEntityData<?> data)
 	{
 		bringUpAnimation = 0F;
 	}
 	
 	@Override
-	public void perform(BipedEntityData<?, ?> data)
+	public void perform(BipedEntityData<?> data)
 	{
 		float ticks = DataUpdateHandler.getTicks();
 		

--- a/src/main/java/net/gobbob/mobends/standard/animation/bit/biped/FallingAnimationBit.java
+++ b/src/main/java/net/gobbob/mobends/standard/animation/bit/biped/FallingAnimationBit.java
@@ -6,20 +6,20 @@ import net.gobbob.mobends.standard.data.BipedEntityData;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.util.math.MathHelper;
 
-public class FallingAnimationBit extends AnimationBit<BipedEntityData<?, ?>>
+public class FallingAnimationBit extends AnimationBit<BipedEntityData<?>>
 {
 	private static final String[] ACTIONS = new String[] { "falling" };
 	public static final float TICKS_BEFORE_FALLING = 10;
 	public static final float FALLING_TRANSITION_TICKS = 80;
 
 	@Override
-	public String[] getActions(BipedEntityData<?, ?> entityData)
+	public String[] getActions(BipedEntityData<?> entityData)
 	{
 		return ACTIONS;
 	}
 
 	@Override
-	public void perform(BipedEntityData<?, ?> data)
+	public void perform(BipedEntityData<?> data)
 	{
 		EntityLivingBase living = data.getEntity();
 

--- a/src/main/java/net/gobbob/mobends/standard/animation/bit/biped/FistGuardAnimationBit.java
+++ b/src/main/java/net/gobbob/mobends/standard/animation/bit/biped/FistGuardAnimationBit.java
@@ -1,23 +1,22 @@
 package net.gobbob.mobends.standard.animation.bit.biped;
 
-import net.gobbob.mobends.core.EntityData;
 import net.gobbob.mobends.core.animation.bit.AnimationBit;
 import net.gobbob.mobends.standard.data.BipedEntityData;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.util.EnumHandSide;
 
-public class FistGuardAnimationBit extends AnimationBit<BipedEntityData<?, ?>>
+public class FistGuardAnimationBit extends AnimationBit<BipedEntityData<?>>
 {
 	private static final String[] ACTIONS = new String[] { "fist_guard" };
 	
 	@Override
-	public String[] getActions(BipedEntityData<?, ?> entityData)
+	public String[] getActions(BipedEntityData<?> entityData)
 	{
 		return ACTIONS;
 	}
 
 	@Override
-	public void perform(BipedEntityData<?, ?> data)
+	public void perform(BipedEntityData<?> data)
 	{
 		EntityLivingBase living = data.getEntity();
 		EnumHandSide primaryHand = living.getPrimaryHand();

--- a/src/main/java/net/gobbob/mobends/standard/animation/bit/biped/JumpAnimationBit.java
+++ b/src/main/java/net/gobbob/mobends/standard/animation/bit/biped/JumpAnimationBit.java
@@ -5,7 +5,7 @@ import net.gobbob.mobends.standard.data.BipedEntityData;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.util.math.MathHelper;
 
-public class JumpAnimationBit<T extends BipedEntityData<?, ?>> extends AnimationBit<T>
+public class JumpAnimationBit<T extends BipedEntityData<?>> extends AnimationBit<T>
 {
 	private static final String[] ACTIONS = new String[] { "jump" };
 	

--- a/src/main/java/net/gobbob/mobends/standard/animation/bit/biped/LadderClimbAnimationBit.java
+++ b/src/main/java/net/gobbob/mobends/standard/animation/bit/biped/LadderClimbAnimationBit.java
@@ -7,18 +7,18 @@ import net.gobbob.mobends.standard.data.BipedEntityData;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.util.math.MathHelper;
 
-public class LadderClimbAnimationBit extends AnimationBit<BipedEntityData<?, ?>>
+public class LadderClimbAnimationBit extends AnimationBit<BipedEntityData<?>>
 {
 	private static final String[] ACTIONS = new String[] { "ladder_climb" };
 	
 	@Override
-	public String[] getActions(BipedEntityData<?, ?> entityData)
+	public String[] getActions(BipedEntityData<?> entityData)
 	{
 		return ACTIONS;
 	}
 	
 	@Override
-	public void perform(BipedEntityData<?, ?> data)
+	public void perform(BipedEntityData<?> data)
 	{
 		EntityLivingBase living = data.getEntity();
 		

--- a/src/main/java/net/gobbob/mobends/standard/animation/bit/biped/RidingAnimationBit.java
+++ b/src/main/java/net/gobbob/mobends/standard/animation/bit/biped/RidingAnimationBit.java
@@ -7,20 +7,20 @@ import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.util.math.MathHelper;
 
-public class RidingAnimationBit extends AnimationBit<BipedEntityData<?, ?>>
+public class RidingAnimationBit extends AnimationBit<BipedEntityData<?>>
 {
 	private static final String[] ACTIONS = new String[] { "riding" };
 	
 	private static final float PI = (float) Math.PI;
 	
 	@Override
-	public String[] getActions(BipedEntityData<?, ?> entityData)
+	public String[] getActions(BipedEntityData<?> entityData)
 	{
 		return ACTIONS;
 	}
 
 	@Override
-	public void perform(BipedEntityData<?, ?> data)
+	public void perform(BipedEntityData<?> data)
 	{
 		EntityLivingBase living = data.getEntity();
 		

--- a/src/main/java/net/gobbob/mobends/standard/animation/bit/biped/SittingAnimationBit.java
+++ b/src/main/java/net/gobbob/mobends/standard/animation/bit/biped/SittingAnimationBit.java
@@ -5,18 +5,18 @@ import net.gobbob.mobends.standard.data.BipedEntityData;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.util.math.MathHelper;
 
-public class SittingAnimationBit extends AnimationBit<BipedEntityData<?, ?>>
+public class SittingAnimationBit extends AnimationBit<BipedEntityData<?>>
 {
 	private static final String[] ACTIONS = new String[] { "sitting" };
 
 	@Override
-	public String[] getActions(BipedEntityData<?, ?> entityData)
+	public String[] getActions(BipedEntityData<?> entityData)
 	{
 		return ACTIONS;
 	}
 
 	@Override
-	public void perform(BipedEntityData<?, ?> data)
+	public void perform(BipedEntityData<?> data)
 	{
 		EntityLivingBase living = data.getEntity();
 		

--- a/src/main/java/net/gobbob/mobends/standard/animation/bit/biped/SneakAnimationBit.java
+++ b/src/main/java/net/gobbob/mobends/standard/animation/bit/biped/SneakAnimationBit.java
@@ -1,23 +1,21 @@
 package net.gobbob.mobends.standard.animation.bit.biped;
 
-import net.gobbob.mobends.core.EntityData;
 import net.gobbob.mobends.core.animation.bit.AnimationBit;
-import net.gobbob.mobends.core.pack.BendsPack;
 import net.gobbob.mobends.standard.data.BipedEntityData;
 import net.minecraft.util.math.MathHelper;
 
-public class SneakAnimationBit extends AnimationBit<BipedEntityData<?, ?>>
+public class SneakAnimationBit extends AnimationBit<BipedEntityData<?>>
 {
 	private static final String[] ACTIONS = new String[] { "sneak" };
 	
 	@Override
-	public String[] getActions(BipedEntityData<?, ?> entityData)
+	public String[] getActions(BipedEntityData<?> entityData)
 	{
 		return ACTIONS;
 	}
 
 	@Override
-	public void perform(BipedEntityData<?, ?> data)
+	public void perform(BipedEntityData<?> data)
 	{
 		data.renderOffset.slideY(-1.3F);
 	

--- a/src/main/java/net/gobbob/mobends/standard/animation/bit/biped/SprintAnimationBit.java
+++ b/src/main/java/net/gobbob/mobends/standard/animation/bit/biped/SprintAnimationBit.java
@@ -1,14 +1,10 @@
 package net.gobbob.mobends.standard.animation.bit.biped;
 
-import net.gobbob.mobends.core.EntityData;
 import net.gobbob.mobends.core.animation.bit.AnimationBit;
-import net.gobbob.mobends.core.client.event.DataUpdateHandler;
-import net.gobbob.mobends.core.pack.BendsPack;
 import net.gobbob.mobends.standard.data.BipedEntityData;
-import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.util.math.MathHelper;
 
-public class SprintAnimationBit<T extends BipedEntityData> extends AnimationBit<T>
+public class SprintAnimationBit<T extends BipedEntityData<?>> extends AnimationBit<T>
 {
 	private static String[] ACTIONS = new String[] { "sprint" };
 	

--- a/src/main/java/net/gobbob/mobends/standard/animation/bit/biped/StandAnimationBit.java
+++ b/src/main/java/net/gobbob/mobends/standard/animation/bit/biped/StandAnimationBit.java
@@ -1,15 +1,11 @@
 package net.gobbob.mobends.standard.animation.bit.biped;
 
-import net.gobbob.mobends.core.EntityData;
 import net.gobbob.mobends.core.animation.bit.AnimationBit;
 import net.gobbob.mobends.core.client.event.DataUpdateHandler;
-import net.gobbob.mobends.core.client.event.EntityRenderHandler;
 import net.gobbob.mobends.standard.data.BipedEntityData;
-import net.minecraft.item.ItemSword;
-import net.minecraft.util.EnumHand;
 import net.minecraft.util.math.MathHelper;
 
-public class StandAnimationBit<T extends BipedEntityData> extends AnimationBit<T>
+public class StandAnimationBit<T extends BipedEntityData<?>> extends AnimationBit<T>
 {
 	private static final String[] ACTIONS = new String[] { "stand" };
 	

--- a/src/main/java/net/gobbob/mobends/standard/animation/bit/biped/SwimmingAnimationBit.java
+++ b/src/main/java/net/gobbob/mobends/standard/animation/bit/biped/SwimmingAnimationBit.java
@@ -6,7 +6,7 @@ import net.gobbob.mobends.core.util.GUtil;
 import net.gobbob.mobends.standard.data.BipedEntityData;
 import net.minecraft.util.math.MathHelper;
 
-public class SwimmingAnimationBit extends AnimationBit<BipedEntityData<?, ?>>
+public class SwimmingAnimationBit extends AnimationBit<BipedEntityData<?>>
 {
 	private static final String[] ACTIONS = new String[] { "swimming", "swimming_surface" };
 	private static final String[] ACTIONS_UNDERWATER = new String[] { "swimming", "swimming_deep" };
@@ -17,7 +17,7 @@ public class SwimmingAnimationBit extends AnimationBit<BipedEntityData<?, ?>>
 	private float transitionSpeed = 0.1F;
 	
 	@Override
-	public String[] getActions(BipedEntityData data)
+	public String[] getActions(BipedEntityData<?> data)
 	{
 		if (data.isUnderwater())
 			return ACTIONS_UNDERWATER;
@@ -26,14 +26,14 @@ public class SwimmingAnimationBit extends AnimationBit<BipedEntityData<?, ?>>
 	}
 	
 	@Override
-	public void onPlay(BipedEntityData data)
+	public void onPlay(BipedEntityData<?> data)
 	{
 		transformTransition = 0F;
 		transitionSpeed = .1F;
 	}
 	
 	@Override
-	public void perform(BipedEntityData<?, ?> data)
+	public void perform(BipedEntityData<?> data)
 	{
 		float ticks = DataUpdateHandler.getTicks();
 		

--- a/src/main/java/net/gobbob/mobends/standard/animation/bit/biped/TorchHoldingAnimationBit.java
+++ b/src/main/java/net/gobbob/mobends/standard/animation/bit/biped/TorchHoldingAnimationBit.java
@@ -7,22 +7,21 @@ import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.init.Blocks;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
-import net.minecraft.item.ItemSword;
 import net.minecraft.util.EnumHand;
 import net.minecraft.util.EnumHandSide;
 
-public class TorchHoldingAnimationBit extends AnimationBit<BipedEntityData<?, ?>>
+public class TorchHoldingAnimationBit extends AnimationBit<BipedEntityData<?>>
 {
 	private static final String[] ACTIONS = new String[] { "torch_holding" };
 	
 	@Override
-	public String[] getActions(BipedEntityData<?, ?> data)
+	public String[] getActions(BipedEntityData<?> data)
 	{
 		return ACTIONS;
 	}
 	
 	@Override
-	public void perform(BipedEntityData<?, ?> data)
+	public void perform(BipedEntityData<?> data)
 	{
 		EntityLivingBase living = data.getEntity();
 		EnumHandSide torchHand;

--- a/src/main/java/net/gobbob/mobends/standard/animation/bit/biped/WalkAnimationBit.java
+++ b/src/main/java/net/gobbob/mobends/standard/animation/bit/biped/WalkAnimationBit.java
@@ -1,14 +1,10 @@
 package net.gobbob.mobends.standard.animation.bit.biped;
 
-import org.lwjgl.util.vector.Vector3f;
-
-import net.gobbob.mobends.core.EntityData;
 import net.gobbob.mobends.core.animation.bit.AnimationBit;
-import net.gobbob.mobends.core.client.event.DataUpdateHandler;
 import net.gobbob.mobends.standard.data.BipedEntityData;
 import net.minecraft.util.math.MathHelper;
 
-public class WalkAnimationBit<T extends BipedEntityData<?, ?>> extends AnimationBit<T>
+public class WalkAnimationBit<T extends BipedEntityData<?>> extends AnimationBit<T>
 {
 	private static final String[] ACTIONS = new String[] { "walk" };
 	

--- a/src/main/java/net/gobbob/mobends/standard/animation/bit/pigzombie/StandAnimationBit.java
+++ b/src/main/java/net/gobbob/mobends/standard/animation/bit/pigzombie/StandAnimationBit.java
@@ -1,9 +1,6 @@
 package net.gobbob.mobends.standard.animation.bit.pigzombie;
 
-import net.gobbob.mobends.standard.data.BipedEntityData;
 import net.gobbob.mobends.standard.data.PigZombieData;
-import net.gobbob.mobends.standard.data.ZombieData;
-import net.minecraft.util.math.MathHelper;
 
 public class StandAnimationBit extends net.gobbob.mobends.standard.animation.bit.biped.StandAnimationBit<PigZombieData>
 {

--- a/src/main/java/net/gobbob/mobends/standard/animation/bit/player/AttackAnimationBit.java
+++ b/src/main/java/net/gobbob/mobends/standard/animation/bit/player/AttackAnimationBit.java
@@ -10,14 +10,13 @@ import net.gobbob.mobends.standard.animation.bit.biped.FistGuardAnimationBit;
 import net.gobbob.mobends.standard.data.BipedEntityData;
 import net.gobbob.mobends.standard.data.PlayerData;
 import net.minecraft.client.entity.AbstractClientPlayer;
-import net.minecraft.entity.Entity;
 import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.EnumHand;
 
 public class AttackAnimationBit extends AnimationBit<PlayerData>
 {
-	protected HardAnimationLayer<BipedEntityData> layerBase;
+	protected HardAnimationLayer<BipedEntityData<?>> layerBase;
 	protected AttackStanceAnimationBit bitAttackStance;
 	protected AttackStanceSprintAnimationBit bitAttackStanceSprint;
 	protected AttackSlashUpAnimationBit bitAttackSlashUp;

--- a/src/main/java/net/gobbob/mobends/standard/animation/bit/player/SprintAnimationBit.java
+++ b/src/main/java/net/gobbob/mobends/standard/animation/bit/player/SprintAnimationBit.java
@@ -9,10 +9,11 @@ public class SprintAnimationBit extends net.gobbob.mobends.standard.animation.bi
 	public void perform(PlayerData data)
 	{
 		super.perform(data);
-		
-		if (data.getTicksAfterAttack() < 10) {
+
+		if (data.getTicksAfterAttack() < 10)
+		{
 			data.head.rotation.setSmoothness(0.5F).orientX(MathHelper.wrapDegrees(data.getHeadPitch()))
-		  	  									  .rotateY(MathHelper.wrapDegrees(data.getHeadYaw()));
+					.rotateY(MathHelper.wrapDegrees(data.getHeadYaw()));
 		}
 	}
 }

--- a/src/main/java/net/gobbob/mobends/standard/animation/controller/PigZombieController.java
+++ b/src/main/java/net/gobbob/mobends/standard/animation/controller/PigZombieController.java
@@ -3,12 +3,12 @@ package net.gobbob.mobends.standard.animation.controller;
 import java.util.ArrayList;
 import java.util.List;
 
-import net.gobbob.mobends.core.EntityData;
 import net.gobbob.mobends.core.animation.bit.AnimationBit;
 import net.gobbob.mobends.core.animation.controller.Controller;
 import net.gobbob.mobends.core.animation.layer.HardAnimationLayer;
 import net.gobbob.mobends.core.pack.BendsPack;
 import net.gobbob.mobends.core.pack.variable.BendsVariable;
+import net.gobbob.mobends.standard.animation.bit.biped.AttackSlashUpAnimationBit;
 import net.gobbob.mobends.standard.data.BipedEntityData;
 import net.gobbob.mobends.standard.data.PigZombieData;
 import net.minecraft.entity.monster.EntityPigZombie;
@@ -23,10 +23,10 @@ import net.minecraft.entity.monster.EntityPigZombie;
 public class PigZombieController extends Controller<PigZombieData>
 {
 	final String animationTarget = "pig_zombie";
-	protected HardAnimationLayer<BipedEntityData> layerBase;
-	protected HardAnimationLayer<BipedEntityData> layerAction;
-	protected AnimationBit<? extends BipedEntityData> bitStand, bitWalk, bitJump;
-	protected AnimationBit<? extends BipedEntityData> bitAttack;
+	protected HardAnimationLayer<BipedEntityData<EntityPigZombie>> layerBase;
+	protected HardAnimationLayer<BipedEntityData<?>> layerAction;
+	protected AnimationBit<? extends BipedEntityData<EntityPigZombie>> bitStand, bitWalk, bitJump;
+	protected AttackSlashUpAnimationBit bitAttack;
 	
 	public PigZombieController()
 	{
@@ -60,7 +60,6 @@ public class PigZombieController extends Controller<PigZombieData>
 			}
 		}
 		
-		System.out.println(pigZombie.swingProgress);
 		if (pigZombie.swingProgress > 0)
 		{
 			this.layerAction.playOrContinueBit(this.bitAttack, pigZombieData);

--- a/src/main/java/net/gobbob/mobends/standard/animation/controller/PlayerController.java
+++ b/src/main/java/net/gobbob/mobends/standard/animation/controller/PlayerController.java
@@ -3,7 +3,6 @@ package net.gobbob.mobends.standard.animation.controller;
 import java.util.ArrayList;
 import java.util.List;
 
-import net.gobbob.mobends.core.EntityData;
 import net.gobbob.mobends.core.animation.bit.AnimationBit;
 import net.gobbob.mobends.core.animation.bit.KeyframeAnimationBit;
 import net.gobbob.mobends.core.animation.controller.Controller;
@@ -37,21 +36,21 @@ import net.minecraft.util.EnumHandSide;
 public class PlayerController extends Controller<PlayerData>
 {
 	protected final String ANIMATION_TARGET = "player";
-	protected HardAnimationLayer<BipedEntityData<?, ?>> layerBase;
-	protected HardAnimationLayer<BipedEntityData<?, ?>> layerTorch;
-	protected HardAnimationLayer<BipedEntityData<?, ?>> layerSneak;
-	protected HardAnimationLayer<BipedEntityData<?, ?>> layerAction;
+	protected HardAnimationLayer<BipedEntityData<?>> layerBase;
+	protected HardAnimationLayer<BipedEntityData<?>> layerTorch;
+	protected HardAnimationLayer<BipedEntityData<?>> layerSneak;
+	protected HardAnimationLayer<BipedEntityData<?>> layerAction;
 	protected KeyframeAnimationLayer<PlayerData> layerKeyframe;
 
-	protected AnimationBit<BipedEntityData<?, ?>> bitStand, bitJump, bitSneak, bitLadderClimb,
+	protected AnimationBit<BipedEntityData<?>> bitStand, bitJump, bitSneak, bitLadderClimb,
 			bitSwimming, bitRiding, bitSitting, bitFalling;
 	protected AnimationBit<PlayerData> bitWalk, bitSprint, bitSprintJump;
-	protected AnimationBit<BipedEntityData<?, ?>> bitTorchHolding;
+	protected AnimationBit<BipedEntityData<?>> bitTorchHolding;
 	protected AnimationBit<PlayerData> bitAttack;
 	protected FlyingAnimationBit bitFlying;
 	protected BowAnimationBit bitBow;
 	protected EatingAnimationBit bitEating;
-	protected KeyframeAnimationBit<BipedEntityData<?, ?>> bitBreaking;
+	protected KeyframeAnimationBit<BipedEntityData<?>> bitBreaking;
 
 	protected ArmatureMask upperBodyOnlyMask;
 

--- a/src/main/java/net/gobbob/mobends/standard/client/mutators/PigZombieMutator.java
+++ b/src/main/java/net/gobbob/mobends/standard/client/mutators/PigZombieMutator.java
@@ -3,9 +3,8 @@ package net.gobbob.mobends.standard.client.mutators;
 import java.util.HashMap;
 import java.util.Map;
 
-import net.gobbob.mobends.core.EntityData;
 import net.gobbob.mobends.core.EntityDatabase;
-import net.gobbob.mobends.core.animation.controller.Controller;
+import net.gobbob.mobends.standard.animation.controller.PigZombieController;
 import net.gobbob.mobends.standard.data.PigZombieData;
 import net.minecraft.client.model.ModelZombie;
 import net.minecraft.client.renderer.entity.Render;
@@ -56,8 +55,8 @@ public class PigZombieMutator extends BipedMutator<EntityPigZombie, ModelZombie>
 		data.setLimbSwing(this.limbSwing);
 		data.setLimbSwingAmount(this.limbSwingAmount);
 
-		Controller controller = data.getController();
-		if (controller != null && data.canBeUpdated())
+		PigZombieController controller = data.getController();
+		if (data.canBeUpdated())
 		{
 			controller.perform(data);
 		}

--- a/src/main/java/net/gobbob/mobends/standard/client/mutators/PlayerMutator.java
+++ b/src/main/java/net/gobbob/mobends/standard/client/mutators/PlayerMutator.java
@@ -25,7 +25,7 @@ import net.minecraft.entity.EntityLivingBase;
  */
 public class PlayerMutator extends BipedMutator<AbstractClientPlayer, ModelPlayer>
 {
-	public static HashMap<RenderPlayer, PlayerMutator> mutatorMap = new HashMap<RenderPlayer, PlayerMutator>();
+	public static final HashMap<RenderPlayer, PlayerMutator> mutatorMap = new HashMap<RenderPlayer, PlayerMutator>();
 
 	protected ModelPartChild bodywear;
 	protected ModelPartChild leftArmwear;

--- a/src/main/java/net/gobbob/mobends/standard/client/mutators/ZombieMutator.java
+++ b/src/main/java/net/gobbob/mobends/standard/client/mutators/ZombieMutator.java
@@ -1,12 +1,10 @@
 package net.gobbob.mobends.standard.client.mutators;
 
 import java.util.HashMap;
-import java.util.Map;
 import java.util.Map.Entry;
 
-import net.gobbob.mobends.core.EntityData;
 import net.gobbob.mobends.core.EntityDatabase;
-import net.gobbob.mobends.core.animation.controller.Controller;
+import net.gobbob.mobends.standard.animation.controller.ZombieController;
 import net.gobbob.mobends.standard.data.ZombieData;
 import net.minecraft.client.model.ModelZombie;
 import net.minecraft.client.renderer.entity.RenderLivingBase;
@@ -16,7 +14,7 @@ import net.minecraft.entity.monster.EntityZombie;
 
 public class ZombieMutator<T extends EntityZombie> extends BipedMutator<T, ModelZombie>
 {
-	public static HashMap<RenderZombie, ZombieMutator> mutatorMap = new HashMap<>();
+	private static final HashMap<RenderZombie, ZombieMutator<EntityZombie>> mutatorMap = new HashMap<>();
 	
 	// Should the height of the texture be 64 or 32(half)?
 	protected boolean halfTexture = false;
@@ -56,8 +54,8 @@ public class ZombieMutator<T extends EntityZombie> extends BipedMutator<T, Model
 		data.setLimbSwing(this.limbSwing);
 		data.setLimbSwingAmount(this.limbSwingAmount);
 
-		Controller controller = data.getController();
-		if (controller != null && data.canBeUpdated())
+		ZombieController controller = data.getController();
+		if (data.canBeUpdated())
 		{
 			controller.perform(data);
 		}
@@ -126,7 +124,7 @@ public class ZombieMutator<T extends EntityZombie> extends BipedMutator<T, Model
 	 */
 	public static void refresh()
 	{
-		for (Entry<RenderZombie, ZombieMutator> mutator : mutatorMap.entrySet())
+		for (Entry<RenderZombie, ZombieMutator<EntityZombie>> mutator : mutatorMap.entrySet())
 		{
 			mutator.getValue().mutate(null, mutator.getKey());
 			if (mutator.getValue().layerArmor != null)

--- a/src/main/java/net/gobbob/mobends/standard/client/renderer/entity/mutated/BipedRenderer.java
+++ b/src/main/java/net/gobbob/mobends/standard/client/renderer/entity/mutated/BipedRenderer.java
@@ -15,10 +15,10 @@ public class BipedRenderer<T extends EntityLivingBase> extends MutatedRenderer<T
 	{
 		float scale = 0.0625F;
 		
-		EntityData data = EntityDatabase.instance.get(entity);
+		EntityData<?> data = EntityDatabase.instance.get(entity);
 		if (data instanceof BipedEntityData)
 		{
-			BipedEntityData bipedData = (BipedEntityData) data;
+			BipedEntityData<?> bipedData = (BipedEntityData<?>) data;
 			if (ModConfig.showSwordTrail)
 			{
 				GlStateManager.pushMatrix();

--- a/src/main/java/net/gobbob/mobends/standard/client/renderer/entity/mutated/SpiderRenderer.java
+++ b/src/main/java/net/gobbob/mobends/standard/client/renderer/entity/mutated/SpiderRenderer.java
@@ -1,7 +1,8 @@
 package net.gobbob.mobends.standard.client.renderer.entity.mutated;
 
 import net.gobbob.mobends.core.client.MutatedRenderer;
+import net.minecraft.entity.monster.EntitySpider;
 
-public class SpiderRenderer extends MutatedRenderer
+public class SpiderRenderer<T extends EntitySpider> extends MutatedRenderer<T>
 {
 }

--- a/src/main/java/net/gobbob/mobends/standard/client/renderer/entity/mutated/SquidRenderer.java
+++ b/src/main/java/net/gobbob/mobends/standard/client/renderer/entity/mutated/SquidRenderer.java
@@ -1,7 +1,8 @@
 package net.gobbob.mobends.standard.client.renderer.entity.mutated;
 
 import net.gobbob.mobends.core.client.MutatedRenderer;
+import net.minecraft.entity.passive.EntitySquid;
 
-public class SquidRenderer extends MutatedRenderer
+public class SquidRenderer<T extends EntitySquid> extends MutatedRenderer<T>
 {
 }

--- a/src/main/java/net/gobbob/mobends/standard/client/renderer/entity/mutated/ZombieRenderer.java
+++ b/src/main/java/net/gobbob/mobends/standard/client/renderer/entity/mutated/ZombieRenderer.java
@@ -1,5 +1,7 @@
 package net.gobbob.mobends.standard.client.renderer.entity.mutated;
 
-public class ZombieRenderer extends BipedRenderer
+import net.minecraft.entity.monster.EntityZombie;
+
+public class ZombieRenderer<T  extends EntityZombie> extends BipedRenderer<T>
 {
 }

--- a/src/main/java/net/gobbob/mobends/standard/data/BipedEntityData.java
+++ b/src/main/java/net/gobbob/mobends/standard/data/BipedEntityData.java
@@ -6,7 +6,7 @@ import net.gobbob.mobends.core.util.SmoothOrientation;
 import net.gobbob.mobends.standard.client.renderer.entity.SwordTrail;
 import net.minecraft.entity.EntityLivingBase;
 
-public abstract class BipedEntityData<T extends BipedEntityData, E extends EntityLivingBase> extends LivingEntityData<T, E>
+public abstract class BipedEntityData<E extends EntityLivingBase> extends LivingEntityData<E>
 {
 	/*
 	 * These models need to be represented only
@@ -108,7 +108,8 @@ public abstract class BipedEntityData<T extends BipedEntityData, E extends Entit
 	}
 	
 	@Override
-	public E getEntity() {
-		return super.getEntity();
+	public E getEntity()
+	{
+		return this.entity;
 	}
 }

--- a/src/main/java/net/gobbob/mobends/standard/data/PigZombieData.java
+++ b/src/main/java/net/gobbob/mobends/standard/data/PigZombieData.java
@@ -1,15 +1,20 @@
 package net.gobbob.mobends.standard.data;
 
 import net.gobbob.mobends.standard.animation.controller.PigZombieController;
-import net.gobbob.mobends.standard.animation.controller.ZombieController;
-import net.minecraft.entity.Entity;
 import net.minecraft.entity.monster.EntityPigZombie;
 
-public class PigZombieData extends BipedEntityData<PigZombieData, EntityPigZombie>
+public class PigZombieData extends BipedEntityData<EntityPigZombie>
 {
 	public PigZombieData(EntityPigZombie entity)
 	{
 		super(entity);
-		this.controller = new PigZombieController();
+	}
+	
+	private final PigZombieController controller = new PigZombieController();
+	
+	@Override
+	public PigZombieController getController()
+	{
+		return controller;
 	}
 }

--- a/src/main/java/net/gobbob/mobends/standard/data/PlayerData.java
+++ b/src/main/java/net/gobbob/mobends/standard/data/PlayerData.java
@@ -11,7 +11,7 @@ import net.minecraft.entity.Entity;
 import net.minecraft.init.Items;
 import net.minecraft.util.EnumHand;
 
-public class PlayerData extends BipedEntityData<PlayerData, AbstractClientPlayer>
+public class PlayerData extends BipedEntityData<AbstractClientPlayer>
 {
 	public ModelPart ears;
 	public ModelPart cloak;
@@ -24,7 +24,14 @@ public class PlayerData extends BipedEntityData<PlayerData, AbstractClientPlayer
 	public PlayerData(AbstractClientPlayer entity)
 	{
 		super(entity);
-		this.controller = new PlayerController();
+	}
+	
+	private final PlayerController controller = new PlayerController();
+	
+	@Override
+	public PlayerController getController()
+	{
+		return controller;
 	}
 
 	@Override

--- a/src/main/java/net/gobbob/mobends/standard/data/SpiderData.java
+++ b/src/main/java/net/gobbob/mobends/standard/data/SpiderData.java
@@ -5,7 +5,7 @@ import net.gobbob.mobends.core.client.model.ModelPartTransform;
 import net.gobbob.mobends.standard.animation.controller.SpiderController;
 import net.minecraft.entity.monster.EntitySpider;
 
-public class SpiderData extends LivingEntityData<SpiderData, EntitySpider>
+public class SpiderData extends LivingEntityData<EntitySpider>
 {
 	public ModelPartTransform spiderHead;
     public ModelPartTransform spiderNeck;
@@ -32,7 +32,14 @@ public class SpiderData extends LivingEntityData<SpiderData, EntitySpider>
 	public SpiderData(EntitySpider entity)
 	{
 		super(entity);
-		this.controller = new SpiderController();
+	}
+	
+	private final SpiderController controller = new SpiderController();
+	
+	@Override
+	public SpiderController getController()
+	{
+		return controller;
 	}
 
 	@Override

--- a/src/main/java/net/gobbob/mobends/standard/data/SquidData.java
+++ b/src/main/java/net/gobbob/mobends/standard/data/SquidData.java
@@ -3,10 +3,9 @@ package net.gobbob.mobends.standard.data;
 import net.gobbob.mobends.core.LivingEntityData;
 import net.gobbob.mobends.core.client.model.ModelPartTransform;
 import net.gobbob.mobends.standard.animation.controller.SquidController;
-import net.minecraft.entity.Entity;
 import net.minecraft.entity.passive.EntitySquid;
 
-public class SquidData extends LivingEntityData<SquidData, EntitySquid>
+public class SquidData extends LivingEntityData<EntitySquid>
 {
 	public static final int TENTACLE_SECTIONS = 9;
 	public static final int SECTION_HEIGHT = 18 / TENTACLE_SECTIONS;
@@ -17,7 +16,14 @@ public class SquidData extends LivingEntityData<SquidData, EntitySquid>
 	public SquidData(EntitySquid entity)
 	{
 		super(entity);
-		this.controller = new SquidController();
+	}
+	
+	private final SquidController controller = new SquidController();
+	
+	@Override
+	public SquidController getController()
+	{
+		return controller;
 	}
 
 	@Override

--- a/src/main/java/net/gobbob/mobends/standard/data/ZombieData.java
+++ b/src/main/java/net/gobbob/mobends/standard/data/ZombieData.java
@@ -6,7 +6,7 @@ import net.gobbob.mobends.core.client.event.DataUpdateHandler;
 import net.gobbob.mobends.standard.animation.controller.ZombieController;
 import net.minecraft.entity.monster.EntityZombie;
 
-public class ZombieData extends BipedEntityData<ZombieData, EntityZombie>
+public class ZombieData extends BipedEntityData<EntityZombie>
 {
 	public static final int ANIMATION_SETS_AMOUNT = 2;
 
@@ -20,11 +20,18 @@ public class ZombieData extends BipedEntityData<ZombieData, EntityZombie>
 	public ZombieData(EntityZombie entity)
 	{
 		super(entity);
-		this.controller = new ZombieController();
 		// Getting a pseudo-random animationType based on something
 		// that is shared across clients, so that every players
 		// sees the same variation
 		this.animationSet = ((int) (entity.getEntityId() * 3.61352F)) % ANIMATION_SETS_AMOUNT;
+	}
+	
+	private final ZombieController controller = new ZombieController();
+	
+	@Override
+	public ZombieController getController()
+	{
+		return controller;
 	}
 
 	public int getAnimationSet()
@@ -37,6 +44,8 @@ public class ZombieData extends BipedEntityData<ZombieData, EntityZombie>
 		return this.currentWalkingState;
 	}
 	
+	private final Random random = new Random();
+	
 	@Override
 	public void update(float partialTicks)
 	{
@@ -46,7 +55,6 @@ public class ZombieData extends BipedEntityData<ZombieData, EntityZombie>
 
 		if (this.ticksBeforeStateChange <= 0)
 		{
-			Random random = new Random();
 			this.currentWalkingState = random.nextInt(2);
 			this.ticksBeforeStateChange = 80 + random.nextInt(20);
 		}

--- a/src/main/java/net/gobbob/mobends/standard/previewer/SpiderPreviewer.java
+++ b/src/main/java/net/gobbob/mobends/standard/previewer/SpiderPreviewer.java
@@ -1,17 +1,15 @@
 package net.gobbob.mobends.standard.previewer;
 
-import net.gobbob.mobends.core.EntityData;
 import net.gobbob.mobends.core.EntityDatabase;
 import net.gobbob.mobends.core.animatedentity.Previewer;
 import net.gobbob.mobends.standard.data.SpiderData;
-import net.minecraft.entity.Entity;
 import net.minecraft.entity.monster.EntitySpider;
 
 public class SpiderPreviewer extends Previewer<EntitySpider>
 {
 
 	/*
-	 * The Entity is generated specificly just for preview, so
+	 * The Entity is generated specifically just for preview, so
 	 * it can be manipulated in any way.
 	 */
 	@Override


### PR DESCRIPTION
* Further cleanup of raw generics
* Remove type check in EntityDatabase because entityIds are always incremental (i.e., a newer entity will not have the same entityId as an old one).
* Slight improvements to vector handling in EntityData