### PR TITLE
Update build.gradle,using proper plugin declaration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,13 +1,6 @@
-buildscript {
-    repositories {
-        jcenter()
-        maven { url = "http://files.minecraftforge.net/maven" }
-    }
-    dependencies {
-        classpath 'net.minecraftforge.gradle:ForgeGradle:2.3-SNAPSHOT'
-    }
+plugins {
+  id "net.minecraftforge.gradle.forge" version "2.0.2"
 }
-apply plugin: 'net.minecraftforge.gradle.forge'
 
 version = "test-${getDate()}"
 group = "net.gobbob.mobends" // http://maven.apache.org/guides/mini/guide-naming-conventions.html


### PR DESCRIPTION
When trying to compile the mod using Gradle the line ` apply plugin: 'net.minecraftforge.gradle.forge'` would crash the process. When I googled the error I found this:
https://plugins.gradle.org/plugin/net.minecraftforge.gradle.forge
It would appear the legacy pluging app is no longer supported. 
Below is the error I've received before the change:
```
FAILURE: Build failed with an exception.
* Where:
Build file 'C:\Users\Jonasz\Downloads\MoBends-master-1.12.2\build.gradle' line: 10
* What went wrong:
A problem occurred evaluating root project 'MoBends-master-1.12.2'.                                                                                                                                           > org.gradle.api.internal.TaskOutputsInternal.dir(Ljava/lang/Object;)Lorg/gradle/api/tasks/TaskOutputs;
* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.
* Get more help at https://help.gradle.org                                                                                                                                                                                                                                                                                                                                                                                  Deprecated Gradle features were used in this build, making it incompatible with Gradle 7.0.                                                                                                                   Use '--warning-mode all' to show the individual deprecation warnings.                                                                                                                                         See https://docs.gradle.org/6.3/userguide/command_line_interface.html#sec:command_line_warnings
BUILD FAILED in 1s 
```