### PR TITLE
quick n dirty way to disable swimming animations

### DIFF
--- a/src/main/java/goblinbob/mobends/core/client/event/EntityRenderHandler.java
+++ b/src/main/java/goblinbob/mobends/core/client/event/EntityRenderHandler.java
@@ -4,9 +4,11 @@ import goblinbob.mobends.core.bender.EntityBender;
 import goblinbob.mobends.core.bender.EntityBenderRegistry;
 import goblinbob.mobends.core.data.LivingEntityData;
 import goblinbob.mobends.core.mutators.Mutator;
+import goblinbob.mobends.standard.main.ModConfig;
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.entity.RenderLivingBase;
 import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.entity.player.EntityPlayer;
 import net.minecraftforge.client.event.RenderLivingEvent;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 
@@ -32,7 +34,17 @@ public class EntityRenderHandler
             {
                 final Mutator mutator = entityBender.getMutator(renderer);
                 final LivingEntityData<EntityLivingBase> data = mutator.getData(living);
-                entityBender.beforeRender(data, living, pt);
+
+                if(!living.isInWater())
+                {
+                    entityBender.beforeRender(data, living, pt);
+                }
+                else
+                {
+                    if(!ModConfig.swimModule && living instanceof EntityPlayer)
+                    entityBender.deapplyMutation(event.getRenderer(), living);
+                }
+
             }
         }
         else

--- a/src/main/java/goblinbob/mobends/core/client/event/EntityRenderHandler.java
+++ b/src/main/java/goblinbob/mobends/core/client/event/EntityRenderHandler.java
@@ -41,8 +41,15 @@ public class EntityRenderHandler
                 }
                 else
                 {
+                    //in water
                     if(!ModConfig.swimModule && living instanceof EntityPlayer)
-                    entityBender.deapplyMutation(event.getRenderer(), living);
+                    {
+                        entityBender.deapplyMutation(event.getRenderer(), living);
+                    }else
+                    {
+                        entityBender.beforeRender(data, living, pt);
+                    }
+
                 }
 
             }

--- a/src/main/java/goblinbob/mobends/standard/animation/bit/biped/GunAnimationBit.java
+++ b/src/main/java/goblinbob/mobends/standard/animation/bit/biped/GunAnimationBit.java
@@ -1,0 +1,81 @@
+package goblinbob.mobends.standard.animation.bit.biped;
+
+import goblinbob.mobends.core.animation.bit.AnimationBit;
+import goblinbob.mobends.core.client.model.ModelPartTransform;
+import goblinbob.mobends.core.util.GUtil;
+import goblinbob.mobends.standard.data.BipedEntityData;
+import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.util.EnumHand;
+import net.minecraft.util.EnumHandSide;
+import net.minecraft.util.math.MathHelper;
+
+public class GunAnimationBit extends AnimationBit<BipedEntityData<?>>
+{
+    private static final String[] ACTIONS = new String[] { "bow" };
+
+    protected EnumHandSide actionHand = EnumHandSide.RIGHT;
+
+    @Override
+    public String[] getActions(BipedEntityData<?> entityData)
+    {
+        return ACTIONS;
+    }
+
+    public void setActionHand(EnumHandSide handSide)
+    {
+        this.actionHand = handSide;
+    }
+
+    @Override
+    public void perform(BipedEntityData<?> data)
+    {
+        data.localOffset.slideToZero(0.3F);
+
+        final EntityLivingBase living = data.getEntity();
+        final float headPitch = data.headPitch.get();
+        final float headYaw = data.headYaw.get();
+
+        boolean mainHandSwitch = this.actionHand == EnumHandSide.RIGHT;
+        // Main Hand Direction Multiplier - it helps switch animation sides depending on
+        // what is your main hand.
+        float handDirMtp = mainHandSwitch ? 1 : -1;
+        ModelPartTransform mainArm = mainHandSwitch ? data.rightArm : data.leftArm;
+        ModelPartTransform offArm = mainHandSwitch ? data.leftArm : data.rightArm;
+        ModelPartTransform mainForeArm = mainHandSwitch ? data.rightForeArm : data.leftForeArm;
+        ModelPartTransform offForeArm = mainHandSwitch ? data.leftForeArm : data.rightForeArm;
+
+        int aimedBowDuration = living != null ? Math.min(living.getItemInUseMaxCount(), 15) : 0;
+
+        float bodyTwistY = (((aimedBowDuration - 10) / 5.0f) * -25) * handDirMtp;
+        float var2 = (aimedBowDuration / 10.0f);
+        float var5 = headPitch - 90F;
+        var5 = Math.max(var5, -160);
+        //if(living.getHeldItem(EnumHand.MAIN_HAND).getItem().getCreatorModId() == "");
+
+        float bodyRotationY = -bodyTwistY + headYaw;
+        if (data.isClimbing())
+        {
+            float climbingRotation = data.getClimbingRotation();
+            float renderRotationY = MathHelper.wrapDegrees(living.rotationYaw - headYaw - climbingRotation);
+            bodyRotationY = MathHelper.wrapDegrees(headYaw + renderRotationY);
+
+            data.head.rotation.setSmoothness(0.5F).orientX(headPitch);
+        }
+        else
+        {
+            data.head.rotation.setSmoothness(0.5F).orientX(headPitch)
+                    .rotateY(headYaw - bodyRotationY);
+        }
+
+        data.body.rotation.setSmoothness(.8F).orientY(bodyRotationY);
+
+        mainArm.rotation.setSmoothness(.8F).orientX(headPitch - 90F)
+                .rotateY(bodyTwistY);
+        offArm.rotation.setSmoothness(1F).orientY(handDirMtp).orientX(headPitch - 90F)
+                .rotateY(bodyTwistY);
+
+        mainForeArm.rotation.setSmoothness(1F).orientX(0);
+        offForeArm.rotation.orientX(var2 * -30F);
+    }
+}
+

--- a/src/main/java/goblinbob/mobends/standard/animation/controller/PlayerController.java
+++ b/src/main/java/goblinbob/mobends/standard/animation/controller/PlayerController.java
@@ -51,6 +51,7 @@ public class PlayerController implements IAnimationController<PlayerData>
     protected FlyingAnimationBit bitFlying = new FlyingAnimationBit();
     protected ElytraAnimationBit bitElytra = new ElytraAnimationBit();
     protected BowAnimationBit bitBow = new BowAnimationBit();
+    protected GunAnimationBit bitGun = new GunAnimationBit();
     protected EatingAnimationBit bitEating = new EatingAnimationBit();
     protected HarvestAnimationBit bitHarvest = new HarvestAnimationBit();
     protected ShieldAnimationBit bitShield = new ShieldAnimationBit();
@@ -95,6 +96,13 @@ public class PlayerController implements IAnimationController<PlayerData>
         );
     }
 
+    public static boolean isHoldingGun(Item heldItemMainhand)
+    {
+        ItemClassification classification = ModConfig.getItemClassification(heldItemMainhand);
+
+        return (classification == ModConfig.ItemClassification.GUN);
+    }
+
     public void performActionAnimations(PlayerData data, AbstractClientPlayer player)
     {
         if (player.isEntityAlive() && player.isPlayerSleeping())
@@ -126,6 +134,11 @@ public class PlayerController implements IAnimationController<PlayerData>
         {
             bitBow.setActionHand(armPoseMain == ArmPose.BOW_AND_ARROW ? primaryHand : offHand);
             layerAction.playOrContinueBit(bitBow, data);
+        }
+        else if (isHoldingGun(heldItemMainhand.getItem()))
+        {
+            bitGun.setActionHand(armPoseMain == ArmPose.BOW_AND_ARROW ? primaryHand : offHand);
+            layerAction.playOrContinueBit(bitGun, data);
         }
         else if (isHoldingWeapon(heldItemMainhand.getItem()) || heldItemMainhand.isEmpty())
         {

--- a/src/main/java/goblinbob/mobends/standard/main/ModConfig.java
+++ b/src/main/java/goblinbob/mobends/standard/main/ModConfig.java
@@ -25,6 +25,9 @@ public class ModConfig
     public static boolean showSwordTrail = true;
     @Config.LangKey(ModStatics.MODID + ".config.perform_spin_attack")
     public static boolean performSpinAttack = true;
+    @Config.LangKey(ModStatics.MODID + ".config.swim_module")
+    public static boolean swimModule = true;
+
     @Config.LangKey(ModStatics.MODID + ".config.weapon_items")
     public static String[] weaponItems = new String[] {};
     @Config.LangKey(ModStatics.MODID + ".config.tool_items")

--- a/src/main/java/goblinbob/mobends/standard/main/ModConfig.java
+++ b/src/main/java/goblinbob/mobends/standard/main/ModConfig.java
@@ -32,6 +32,9 @@ public class ModConfig
     public static String[] weaponItems = new String[] {};
     @Config.LangKey(ModStatics.MODID + ".config.tool_items")
     public static String[] toolItems = new String[] {};
+    @Config.LangKey(ModStatics.MODID + ".config.gun_items")
+    public static String[] gunItems = new String[] {};
+
     @Config.LangKey(ModStatics.MODID + ".config.keep_armor_as_vanilla")
     public static String[] keepArmorAsVanilla = new String[] {};
     @Config.LangKey(ModStatics.MODID + ".config.keep_entity_as_vanilla")
@@ -82,6 +85,7 @@ public class ModConfig
         UNKNOWN,
         WEAPON,
         TOOL,
+        GUN
     }
 
     private static boolean checkForPatterns(ResourceLocation resourceLocation, String[] patterns)
@@ -117,6 +121,9 @@ public class ModConfig
 
             if (checkForPatterns(location, weaponItems))
                 return ItemClassification.WEAPON;
+
+            if(checkForPatterns(location, gunItems))
+                return ItemClassification.GUN;
 
             if (checkForPatterns(location, toolItems))
                 return ItemClassification.TOOL;


### PR DESCRIPTION
This change prevents MoBends from animating the player renderer when a player is in water and the swimModule config bool is set to false.

This was built for compatibility with the Better Diving Mod, since using both without this fix caused some visual bugs in the player animation.

If there are any better or more efficient ways to do this, let me know and I will make the changes.